### PR TITLE
Change the HTTP entrypoint to be a http.Handler by default.

### DIFF
--- a/core/extension.go
+++ b/core/extension.go
@@ -47,7 +47,7 @@ func (e *Extension) Init() error {
 	return nil
 }
 
-func (e *Extension) HandleRequest(w http.ResponseWriter, r *http.Request) {
+func (e *Extension) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	defer r.Body.Close()
 
 	ctx := r.Context()

--- a/examples/basic/main.go
+++ b/examples/basic/main.go
@@ -14,41 +14,41 @@ type BasicExtension struct {
 	core.Extension
 }
 
-var extension *BasicExtension
+var Extension *BasicExtension
 
 // Boilerplate Code
 // Serves the extension as a Cloud Function.
 // ============================================================================
 func init() {
-	extension = &BasicExtension{
+	Extension = &BasicExtension{
 		core.Extension{
 			ExtensionName: "basic-extension",
 			SecretKey:     "1234",
 		},
 	}
-	extension.Callbacks = core.ExtensionCallbacks{
+	Extension.Callbacks = core.ExtensionCallbacks{
 		OnSubscribe: func(ctx context.Context, o *limacharlie.Organization) common.Response {
-			extension.LCLoggerZerolog.Info(fmt.Sprintf("subscribe to %s", o.GetOID()))
+			Extension.LCLoggerZerolog.Info(fmt.Sprintf("subscribe to %s", o.GetOID()))
 			return common.Response{}
 		},
 		OnUnsubscribe: func(ctx context.Context, o *limacharlie.Organization) common.Response {
-			extension.LCLoggerZerolog.Info(fmt.Sprintf("unsubscribe from %s", o.GetOID()))
+			Extension.LCLoggerZerolog.Info(fmt.Sprintf("unsubscribe from %s", o.GetOID()))
 			return common.Response{}
 		},
 		RequestHandlers: map[string]core.RequestCallback{
 			"ping": {
 				RequestStruct: &PingRequest{},
-				Callback:      extension.OnPing,
+				Callback:      Extension.OnPing,
 			},
 		},
 	}
-	if err := extension.Init(); err != nil {
+	if err := Extension.Init(); err != nil {
 		panic(err)
 	}
 }
 
 func Process(w http.ResponseWriter, r *http.Request) {
-	extension.HandleRequest(w, r)
+	Extension.ServeHTTP(w, r)
 }
 
 // Actual Extension Implementation


### PR DESCRIPTION
## Description of the change

This will simplify running Extensions in a container or webserver.

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

