### PR TITLE
Remove scheduling events, now use scheduler dr rules.

### DIFF
--- a/common/messages.go
+++ b/common/messages.go
@@ -84,19 +84,7 @@ type SensorUpdate struct {
 var EventTypes = struct {
 	Subscribe   EventName
 	Unsubscribe EventName
-	Every1Hour  EventName
-	Every3Hour  EventName
-	Every12Hour EventName
-	Every24Hour EventName
-	Every7Day   EventName
-	Every30Day  EventName
 }{
 	Subscribe:   "subscribe",
 	Unsubscribe: "unsubscribe",
-	Every1Hour:  "every_1h",
-	Every3Hour:  "every_3h",
-	Every12Hour: "every_12h",
-	Every24Hour: "every_24h",
-	Every7Day:   "every_7d",
-	Every30Day:  "every_30d",
 }


### PR DESCRIPTION
## Description of the change

No more scheduling events directly in extensions. This can now be achieved through the schedule events in D&R rules.

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

