### PR TITLE
Make examples refect that time and duration should be miliseconds.

### DIFF
--- a/common/config_schema.go
+++ b/common/config_schema.go
@@ -57,6 +57,6 @@ type ConfigElement struct {
 // {
 // 	"enable_new_rules": true,
 // 	"suppression": {
-// 		"suppression_time": "3h",
+// 		"suppression_time": 10800000,
 // 	}
 // }

--- a/common/request_schema.go
+++ b/common/request_schema.go
@@ -111,7 +111,7 @@ var ParameterDataTypes = struct {
 // 			"time_to_live": {
 // 				"is_required": false,
 // 				"data_type": "duration",
-// 				"default_value": "60m",
+// 				"default_value": 3600000,
 // 				"display_index": 2,
 // 			}
 // 		},


### PR DESCRIPTION
## Description of the change

We need to be universal in the datatypes we define so that Python and other languages can also implement an Extension.

@oklex 

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


