### PR TITLE
Add two new Tuble related def for Requests.

### DIFF
--- a/common/request_schema.go
+++ b/common/request_schema.go
@@ -35,6 +35,8 @@ type RequestParameterDefinitions struct {
 type RequestParameterDefinition struct {
 	Label        Label             `json:"label,omitempty" msgpack:"label,omitempty"`                 // Human readable label.
 	IsList       bool              `json:"is_list,omitempty" msgpack:"is_list,omitempty"`             // Is this Parameter for a single item, or a list of items?
+	IsTuple      bool              `json:"is_tuple,omitempty" msgpack:"is_tuple,omitempty"`           // This is a tuple of this datatype.
+	TupleSize    int               `json:"tuple_size,omitempty" msgpack:"tuple_size,omitempty"`       // The number of items in the tuple(s).
 	DataType     ParameterDataType `json:"data_type" msgpack:"data_type"`                             // The type of values expected.
 	DefaultValue interface{}       `json:"default_value,omitempty" msgpack:"default_value,omitempty"` // If a default value should be set for is_required: false Parameters.
 	EnumValues   []interface{}     `json:"enum_values,omitempty" msgpack:"enum_values,omitempty"`     // If the type is enum, these are the possible values.


### PR DESCRIPTION
## Description of the change

Suggested implementation, but also RFC.
This adds a bool `IsTuple` to indicate the given param is really a tuple of the datatype and a `TupleSize` to force the size of that tuple.

The idea is that this introduces the possibility to make a list of string tuples like:
```
{
  "search_params": [
    ["imp_hash", "=", "abcdef"],
    ["signer", "LIKE", "%evil%"]
  ]
}
```
with `is_tuple = true` and `tuple_size = 3`.

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


