### PR TITLE
added keyName field

### DIFF
--- a/common/config_schema.go
+++ b/common/config_schema.go
@@ -13,6 +13,7 @@ type SchemaObject struct {
 	// -------------------------------------------
 	RenderType  string         `json:"render_type,omitempty" msgpack:"render_type,omitempty"`
 	KeyDataType SchemaDataType `json:"key_data_type,omitempty" msgpack:"key_data_type,omitempty"`
+	KeyName     string         `json:"key_name,omitempty" msgpack:"key_name,omitempty"`
 
 	// Extended definition for Interactive elements
 	// like Configs and Requests.


### PR DESCRIPTION
## Description of the change

When replacing a `*` matching key, the field will need a new name to assign the key value to. 

I'm beginning to think it might just make sense to add a field of a schemaElement on a field 'key' but we can probably consider it later after things are working. 

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Fix [#1]() 

## Describe multi-tenancy segmentation

