### PR TITLE
added more key config fields

### DIFF
--- a/common/config_schema.go
+++ b/common/config_schema.go
@@ -11,9 +11,11 @@ type SchemaObject struct {
 	// Extended definition for Response elements.
 	// Not available at the root of the Response.
 	// -------------------------------------------
-	RenderType  string         `json:"render_type,omitempty" msgpack:"render_type,omitempty"`
-	KeyDataType SchemaDataType `json:"key_data_type,omitempty" msgpack:"key_data_type,omitempty"`
-	KeyName     string         `json:"key_name,omitempty" msgpack:"key_name,omitempty"`
+	RenderType      string         `json:"render_type,omitempty" msgpack:"render_type,omitempty"`
+	KeyDataType     SchemaDataType `json:"key_data_type,omitempty" msgpack:"key_data_type,omitempty"`
+	KeyName         string         `json:"key_name,omitempty" msgpack:"key_name,omitempty"`
+	KeyLabel        string         `json:"key_label,omitempty" msgpack:"key_name,omitempty"`
+	KeyDisplayIndex int            `json:"key_display_index,omitempty" msgpack:"display_index,omitempty"`
 
 	// Extended definition for Interactive elements
 	// like Configs and Requests.

--- a/python/Dockerfile
+++ b/python/Dockerfile
@@ -2,7 +2,7 @@ FROM debian:bookworm-slim
 
 # Update / install python
 RUN apt update && apt -y upgrade
-RUN apt install -y python3.10 python3-setuptools python3-pip --fix-missing
+RUN apt install -y python3.11 python3-setuptools python3-pip --fix-missing
 
 # Install base library.
 ADD . /lc-extension

--- a/python/Dockerfile
+++ b/python/Dockerfile
@@ -2,7 +2,7 @@ FROM debian:bookworm-slim
 
 # Update / install python
 RUN apt update && apt -y upgrade
-RUN apt install -y python3.11 python3-setuptools python3-pip --fix-missing
+RUN apt install -y python3.10 python3-setuptools python3-pip --fix-missing
 
 # Install base library.
 ADD . /lc-extension

--- a/python/lcextension/schema.py
+++ b/python/lcextension/schema.py
@@ -3,6 +3,8 @@ class SchemaObject(object):
         self.Fields = {} # {} of Field name to SchemaElement
         self.RenderType = None
         self.KeyDataType = None # SchemaDataTypes
+        self.KeyLabel = None # SchemaDataTypes
+        self.KeyDisplayIndex = None # SchemaDataTypes
         self.KeyName = None
         self.Requirements = [] # [] of [] of Field names
         for k, v in kwargs.items():
@@ -16,6 +18,8 @@ class SchemaObject(object):
             'render_type' : self.RenderType,
             'key_data_type' : self.KeyDataType,
             'key_name' : self.KeyName,
+            'key_label' : self.KeyLabel,
+            'key_display_index' : self.KeyDisplayIndex,
             'requirements' : self.Requirements,
         }
 


### PR DESCRIPTION
## Description of the change

This pr introduces an expansion to the response schema to include more 'key_' fields. For example, the fields `keyDisplayIndex` and `keyLabel`.

This will allow me on the FE to (essentially) re-assemble the key into schemaParam. Which means that in a scenario like reliable-tasking, adding the key display index will allow me to position it first on the reliable tasking (list response) table, and adding the label will allow me to name it smth like "sensor id".

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

