### PR TITLE
added record and event data type

### DIFF
--- a/common/config_schema.go
+++ b/common/config_schema.go
@@ -8,8 +8,11 @@ type SchemaKey = string
 type SchemaObject struct {
 	Fields map[SchemaKey]SchemaElement `json:"fields" msgpack:"fields"`
 
-	// Extended definition for Response elements.
-	// Not available at the root of the Response.
+	// If this element is a type "Record" object, field "key" defines the keys
+	// whereas "fields" are the objects belonging to the keys
+	Key SchemaElement `json:"key,omitempty" msgpack:"key,omitempty"`
+
+	// legacy fields
 	// -------------------------------------------
 	RenderType      string         `json:"render_type,omitempty" msgpack:"render_type,omitempty"`
 	KeyDataType     SchemaDataType `json:"key_data_type,omitempty" msgpack:"key_data_type,omitempty"`

--- a/common/config_schema.go
+++ b/common/config_schema.go
@@ -11,6 +11,8 @@ type SchemaObject struct {
 	// If this element is a type "Record" object, field "key" defines the keys
 	// whereas "fields" are the objects belonging to the keys
 	Key SchemaElement `json:"key,omitempty" msgpack:"key,omitempty"`
+	// what to call each element in the record/list - use for auto generated copy/labels
+	ListElementName string `json:"list_element_name,omitempty" msgpack:"list_element_name,omitempty"`
 
 	// legacy fields
 	// -------------------------------------------

--- a/common/request_schema.go
+++ b/common/request_schema.go
@@ -43,6 +43,7 @@ var SchemaDataTypes = struct {
 	Platform       string
 	Architecture   string
 	SensorSelector string
+	Event          string
 
 	Tag string
 
@@ -55,10 +56,11 @@ var SchemaDataTypes = struct {
 	JSON string
 	YAML string
 
-	Object string
-
 	YaraRule     string
 	YaraRuleName string
+
+	Object string
+	Record string
 }{
 	String:  "string",
 	Integer: "integer",
@@ -70,6 +72,7 @@ var SchemaDataTypes = struct {
 	Platform:       "platform",
 	Architecture:   "architecture",
 	SensorSelector: "sensor_selector",
+	Event:          "event",
 
 	Tag: "tag",
 
@@ -82,10 +85,11 @@ var SchemaDataTypes = struct {
 	JSON: "json",
 	YAML: "yaml",
 
-	Object: "object",
-
 	YaraRule:     "yara_rule",
 	YaraRuleName: "yara_rule_name",
+
+	Object: "object",
+	Record: "record",
 }
 
 // Examples of full schemas for something like a Yara Scanning Extension:

--- a/common/request_schema.go
+++ b/common/request_schema.go
@@ -43,7 +43,7 @@ var SchemaDataTypes = struct {
 	Platform       string
 	Architecture   string
 	SensorSelector string
-	Event          string
+	EventName      string
 
 	Tag string
 
@@ -72,7 +72,7 @@ var SchemaDataTypes = struct {
 	Platform:       "platform",
 	Architecture:   "architecture",
 	SensorSelector: "sensor_selector",
-	Event:          "event",
+	EventName:      "event_name",
 
 	Tag: "tag",
 

--- a/python/lcextension/schema.py
+++ b/python/lcextension/schema.py
@@ -1,12 +1,15 @@
 class SchemaObject(object):
     def __init__(self, **kwargs):
         self.Fields = {} # {} of Field name to SchemaElement
+        self.Key = None
+        self.Requirements = [] # [] of [] of Field names
+
+        # legacy
         self.RenderType = None
         self.KeyDataType = None # SchemaDataTypes
         self.KeyLabel = None # SchemaDataTypes
         self.KeyDisplayIndex = None # SchemaDataTypes
         self.KeyName = None
-        self.Requirements = [] # [] of [] of Field names
         for k, v in kwargs.items():
             if not hasattr(self, k):
                 raise Exception(f"unknown attribute {k}")
@@ -15,12 +18,15 @@ class SchemaObject(object):
     def serialize(self):
         return {
             'fields' : {n: f.serialize() for n, f in self.Fields.items()},
+            'key': self.Key
+            'requirements' : self.Requirements,
+
+            # legacy
             'render_type' : self.RenderType,
             'key_data_type' : self.KeyDataType,
             'key_name' : self.KeyName,
             'key_label' : self.KeyLabel,
             'key_display_index' : self.KeyDisplayIndex,
-            'requirements' : self.Requirements,
         }
 
 class SchemaElement(object):
@@ -109,6 +115,7 @@ class SchemaDataTypes(object):
     Platform = "platform"
     Architecture = "architecture"
     SensorSelector = "sensor_selector"
+    Event = 'event'
     Tag = "tag"
     Duration = "duration" # milliseconds
     Time = "time" # milliseconds since epoch
@@ -116,6 +123,7 @@ class SchemaDataTypes(object):
     Domain = "domain"
     JSON = "json"
     YAML = "yaml"
-    Object = "object"
     YaraRule = "yara_rule"
     YaraRuleName = "yara_rule_name"
+    Object = "object"
+    Record = "record"

--- a/python/lcextension/schema.py
+++ b/python/lcextension/schema.py
@@ -117,7 +117,7 @@ class SchemaDataTypes(object):
     Platform = "platform"
     Architecture = "architecture"
     SensorSelector = "sensor_selector"
-    Event = 'event'
+    EventName = 'event_name'
     Tag = "tag"
     Duration = "duration" # milliseconds
     Time = "time" # milliseconds since epoch

--- a/python/lcextension/schema.py
+++ b/python/lcextension/schema.py
@@ -2,6 +2,7 @@ class SchemaObject(object):
     def __init__(self, **kwargs):
         self.Fields = {} # {} of Field name to SchemaElement
         self.Key = None
+        self.ListElementName = None
         self.Requirements = [] # [] of [] of Field names
 
         # legacy
@@ -18,6 +19,7 @@ class SchemaObject(object):
     def serialize(self):
         return {
             'fields' : {n: f.serialize() for n, f in self.Fields.items()},
+            'list_element_name': self.ListElementName
             'key': self.Key
             'requirements' : self.Requirements,
 


### PR DESCRIPTION
## Description of the change

I'm creating a new data type for "record" that is basically an object we want to treat like a list. This solves two problems:
(1) where `render_type` and various `key_(x)` props needed to be added,
(2) where we needed to have 3 consecutive nested object like ```list: { fields: '*': { fields: { name: 'x' } }}``` where it's confusing on what's going on at which level `render_type` is suppose to go. 

Now with 'record' type, we just specify a 'key' value (as a schema element) as a sibling field to the 'fields', making it very intuitive with no weird nesting or field/option names to remember. 

for example:
```
            watch: {
              data_type: 'record',
              label: 'Watch Rules',
              object: {
                list_element_name: 'Watch Rule',
                key: {
                  name: 'name',
                  data_type: 'string',
                  display_index: 1,
                },
                list_element_name: 'Watch Rule',
                fields: {
                  event: {
                    label: 'Event Type',
                    data_type: 'string',
                    placeholder: 'Select event...',
                    is_list: false,
                    description:
                      'High volume events not shown - those must be configured via Watch rules',
                  },
```
On a scale of ("yes" to "10") it's pretty intuitive now

Also adding:
1. a field in the 'object schema' for 'ListElementName' that is used on button and label copy
2. a new type of 'event'.

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

