### PR TITLE
Move all maps to Dict.

### DIFF
--- a/core/extension.go
+++ b/core/extension.go
@@ -35,18 +35,18 @@ type ExtensionResponse struct {
 }
 
 type ExtensionCallbacks struct {
-	ValidateConfig  func(context.Context, *limacharlie.Organization, map[string]interface{}) common.Response // Optional
-	RequestHandlers map[common.ActionName]RequestCallback                                                    // Optional
+	ValidateConfig  func(context.Context, *limacharlie.Organization, limacharlie.Dict) common.Response // Optional
+	RequestHandlers map[common.ActionName]RequestCallback                                              // Optional
 	EventHandlers   map[common.EventName]EventCallback
 	ErrorHandler    func(*common.ErrorReportMessage)
 }
 
 type RequestCallback struct {
 	RequestStruct interface{}
-	Callback      func(ctx context.Context, org *limacharlie.Organization, req interface{}, conf map[string]interface{}, idempotentKey string) common.Response
+	Callback      func(ctx context.Context, org *limacharlie.Organization, req interface{}, conf limacharlie.Dict, idempotentKey string) common.Response
 }
 
-type EventCallback = func(ctx context.Context, org *limacharlie.Organization, data map[string]interface{}, conf map[string]interface{}, idempotentKey string) common.Response
+type EventCallback = func(ctx context.Context, org *limacharlie.Organization, data limacharlie.Dict, conf limacharlie.Dict, idempotentKey string) common.Response
 
 func (e *Extension) Init() error {
 	return nil

--- a/examples/basic/main.go
+++ b/examples/basic/main.go
@@ -67,7 +67,7 @@ func init() {
 	// Callbacks receiving webhooks from LimaCharlie.
 	Extension.Callbacks = core.ExtensionCallbacks{
 		// When a user changes a config for this Extension, you will be asked to validate it.
-		ValidateConfig: func(ctx context.Context, org *limacharlie.Organization, config map[string]interface{}) common.Response {
+		ValidateConfig: func(ctx context.Context, org *limacharlie.Organization, config limacharlie.Dict) common.Response {
 			Extension.Info(fmt.Sprintf("validate config from %s", org.GetOID()))
 			return common.Response{} // No error, so success.
 		},
@@ -80,12 +80,12 @@ func init() {
 		// Events occuring in LimaCharlie that we need to be made aware of.
 		EventHandlers: map[common.EventName]core.EventCallback{
 			// An Org subscribed.
-			common.EventTypes.Subscribe: func(ctx context.Context, org *limacharlie.Organization, data, conf map[string]interface{}, idempotentKey string) common.Response {
+			common.EventTypes.Subscribe: func(ctx context.Context, org *limacharlie.Organization, data, conf limacharlie.Dict, idempotentKey string) common.Response {
 				Extension.Info(fmt.Sprintf("subscribe to %s", org.GetOID()))
 				return common.Response{}
 			},
 			// An Org unsubscribed.
-			common.EventTypes.Unsubscribe: func(ctx context.Context, org *limacharlie.Organization, data, conf map[string]interface{}, idempotentKey string) common.Response {
+			common.EventTypes.Unsubscribe: func(ctx context.Context, org *limacharlie.Organization, data, conf limacharlie.Dict, idempotentKey string) common.Response {
 				Extension.Info(fmt.Sprintf("unsubscribe from %s", org.GetOID()))
 				return common.Response{}
 			},
@@ -119,7 +119,7 @@ func (e *BasicExtension) Init() error {
 	return nil
 }
 
-func (e *BasicExtension) OnPing(ctx context.Context, org *limacharlie.Organization, data interface{}, conf map[string]interface{}, idempotentKey string) common.Response {
+func (e *BasicExtension) OnPing(ctx context.Context, org *limacharlie.Organization, data interface{}, conf limacharlie.Dict, idempotentKey string) common.Response {
 	request := data.(*PingRequest)
 
 	return common.Response{

--- a/simplified/lookup.go
+++ b/simplified/lookup.go
@@ -54,7 +54,7 @@ func (l *LookupExtension) Init() (*core.Extension, error) {
 	}
 
 	x.Callbacks = core.ExtensionCallbacks{
-		ValidateConfig: func(ctx context.Context, org *limacharlie.Organization, config map[string]interface{}) common.Response {
+		ValidateConfig: func(ctx context.Context, org *limacharlie.Organization, config limacharlie.Dict) common.Response {
 			return common.Response{}
 		},
 		RequestHandlers: map[common.ActionName]core.RequestCallback{
@@ -64,7 +64,7 @@ func (l *LookupExtension) Init() (*core.Extension, error) {
 			},
 		},
 		EventHandlers: map[common.EventName]core.EventCallback{
-			common.EventTypes.Subscribe: func(ctx context.Context, org *limacharlie.Organization, data, conf map[string]interface{}, idempotentKey string) common.Response {
+			common.EventTypes.Subscribe: func(ctx context.Context, org *limacharlie.Organization, data, conf limacharlie.Dict, idempotentKey string) common.Response {
 				l.Logger.Info(fmt.Sprintf("subscribe to %s", org.GetOID()))
 
 				// We set up a D&R rule for recurring update.
@@ -104,7 +104,7 @@ func (l *LookupExtension) Init() (*core.Extension, error) {
 				return common.Response{}
 			},
 			// An Org unsubscribed.
-			common.EventTypes.Unsubscribe: func(ctx context.Context, org *limacharlie.Organization, data, conf map[string]interface{}, idempotentKey string) common.Response {
+			common.EventTypes.Unsubscribe: func(ctx context.Context, org *limacharlie.Organization, data, conf limacharlie.Dict, idempotentKey string) common.Response {
 				l.Logger.Info(fmt.Sprintf("unsubscribe from %s", org.GetOID()))
 
 				// Remove the D&R rule we set up.
@@ -163,7 +163,7 @@ func (l *LookupExtension) Init() (*core.Extension, error) {
 	return x, nil
 }
 
-func (l *LookupExtension) onUpdate(ctx context.Context, org *limacharlie.Organization, data interface{}, conf map[string]interface{}, idempotentKey string) common.Response {
+func (l *LookupExtension) onUpdate(ctx context.Context, org *limacharlie.Organization, data interface{}, conf limacharlie.Dict, idempotentKey string) common.Response {
 	h := limacharlie.NewHiveClient(org)
 
 	wg := sync.WaitGroup{}


### PR DESCRIPTION
## Description of the change

Move all usage of `map[string]interface{}` to `limacharlie.Dict` to avoid JSON serialization issues with uint64.

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

