### PR TITLE
Updated schema with fields for platform whitelist/blacklist, and numerical min/max

### DIFF
--- a/common/config_schema.go
+++ b/common/config_schema.go
@@ -42,13 +42,12 @@ type RecordKey = struct {
 type RequiredFields = []SchemaKey
 
 // for sid and platforms data_type
-type PlatformFilterType = struct {
+type FilterType = struct {
+	// whitelist and blacklist are mutually exclusive
+	// for platforms, sid platforms, string chars
 	Whitelist []string `json:"whitelist,omitempty" msgpack:"whitelist,omitempty"`
 	Blacklist []string `json:"blacklist,omitempty" msgpack:"blacklist,omitempty"`
-}
-
-// for number and time/date data_types
-type NumericLimitType = struct {
+	// for number and time/date data_types
 	Min []string `json:"min,omitempty" msgpack:"min,omitempty"`
 	Max []string `json:"max,omitempty" msgpack:"max,omitempty"`
 }
@@ -68,9 +67,8 @@ type SchemaElement struct {
 
 	// Extended definition for Interactive elements
 	// -------------------------------------------
-	EnumValues     []interface{}      `json:"enum_values,omitempty" msgpack:"enum_values,omitempty"` // If the type is enum, these are the possible values.
-	PlatformFilter PlatformFilterType `json:"platform_filter,omitempty" msgpack:"platform_filter,omitempty"`
-	Limit          PlatformFilterType `json:"limit,omitempty" msgpack:"limit,omitempty"`
+	EnumValues []interface{} `json:"enum_values,omitempty" msgpack:"enum_values,omitempty"` // If the type is enum, these are the possible values.
+	Filter     FilterType    `json:"filter,omitempty" msgpack:"filter,omitempty"`
 
 	// Extended definition for Actionable elements
 	// like Configs and Responses.

--- a/common/config_schema.go
+++ b/common/config_schema.go
@@ -42,10 +42,10 @@ type RecordKey = struct {
 type RequiredFields = []SchemaKey
 
 // for sid and platforms data_type
-type FilterType = struct {
+type Validator = struct {
 	// whitelist and blacklist are mutually exclusive
 	// for platforms, sid platforms, string chars
-	ValidRE []string `json:"valid_re,omitempty" msgpack:"valid_re,omitempty"`
+	ValidRE   []string `json:"valid_re,omitempty" msgpack:"valid_re,omitempty"`
 	InvalidRE []string `json:"invalid_re,omitempty" msgpack:"invalid_re,omitempty"`
 	// for number and time/date data_types
 	Min []string `json:"min,omitempty" msgpack:"min,omitempty"`
@@ -68,7 +68,7 @@ type SchemaElement struct {
 	// Extended definition for Interactive elements
 	// -------------------------------------------
 	EnumValues []interface{} `json:"enum_values,omitempty" msgpack:"enum_values,omitempty"` // If the type is enum, these are the possible values.
-	Filter     FilterType    `json:"filter,omitempty" msgpack:"filter,omitempty"`
+	Filter     Validator     `json:"filter,omitempty" msgpack:"filter,omitempty"`
 
 	// Extended definition for Actionable elements
 	// like Configs and Responses.

--- a/common/config_schema.go
+++ b/common/config_schema.go
@@ -30,7 +30,7 @@ type SchemaObject struct {
 }
 
 type RecordKey = struct {
-	Name         string         `json:"name" msgpack:"name"`
+	Name         string         `json:"name,omitempty" msgpack:"name,omitempty"`
 	Label        Label          `json:"label,omitempty" msgpack:"label,omitempty"` // Human readable label.
 	Description  string         `json:"description,omitempty" msgpack:"description,omitempty"`
 	DataType     SchemaDataType `json:"data_type,omitempty" msgpack:"data_type,omitempty"`

--- a/common/config_schema.go
+++ b/common/config_schema.go
@@ -41,9 +41,22 @@ type RecordKey = struct {
 // Valid objects require one of the following fields to be specified.
 type RequiredFields = []SchemaKey
 
+// for sid and platforms data_type
+type PlatformFilterType = struct {
+	Whitelist []string `json:"whitelist,omitempty" msgpack:"whitelist,omitempty"`
+	Blacklist []string `json:"blacklist,omitempty" msgpack:"blacklist,omitempty"`
+}
+
+// for number and time/date data_types
+type NumericLimitType = struct {
+	Min []string `json:"min,omitempty" msgpack:"min,omitempty"`
+	Max []string `json:"max,omitempty" msgpack:"max,omitempty"`
+}
+
 type SchemaElement struct {
 	Label        Label          `json:"label,omitempty" msgpack:"label,omitempty"` // Human readable label.
 	Description  string         `json:"description" msgpack:"description"`
+	PlaceHolder  string         `json:"placeholder,omitempty" msgpack:"placeholder,omitempty"` // Placeholder to display for this field.
 	DataType     SchemaDataType `json:"data_type" msgpack:"data_type"`
 	IsList       bool           `json:"is_list,omitempty" msgpack:"is_list,omitempty"` // Is this Parameter for a single item, or a list of items?
 	DisplayIndex int            `json:"display_index,omitempty" msgpack:"display_index,omitempty"`
@@ -54,10 +67,10 @@ type SchemaElement struct {
 	Object *SchemaObject `json:"object,omitempty" msgpack:"object,omitempty"`
 
 	// Extended definition for Interactive elements
-	// like Configs and Requests.
 	// -------------------------------------------
-	EnumValues  []interface{} `json:"enum_values,omitempty" msgpack:"enum_values,omitempty"` // If the type is enum, these are the possible values.
-	PlaceHolder string        `json:"placeholder,omitempty" msgpack:"placeholder,omitempty"` // Placeholder to display for this field.
+	EnumValues     []interface{}      `json:"enum_values,omitempty" msgpack:"enum_values,omitempty"` // If the type is enum, these are the possible values.
+	PlatformFilter PlatformFilterType `json:"platform_filter,omitempty" msgpack:"platform_filter,omitempty"`
+	Limit          PlatformFilterType `json:"limit,omitempty" msgpack:"limit,omitempty"`
 
 	// Extended definition for Actionable elements
 	// like Configs and Responses.

--- a/common/config_schema.go
+++ b/common/config_schema.go
@@ -45,8 +45,8 @@ type RequiredFields = []SchemaKey
 type FilterType = struct {
 	// whitelist and blacklist are mutually exclusive
 	// for platforms, sid platforms, string chars
-	Whitelist []string `json:"whitelist,omitempty" msgpack:"whitelist,omitempty"`
-	Blacklist []string `json:"blacklist,omitempty" msgpack:"blacklist,omitempty"`
+	ValidRE []string `json:"valid_re,omitempty" msgpack:"valid_re,omitempty"`
+	InvalidRE []string `json:"invalid_re,omitempty" msgpack:"invalid_re,omitempty"`
 	// for number and time/date data_types
 	Min []string `json:"min,omitempty" msgpack:"min,omitempty"`
 	Max []string `json:"max,omitempty" msgpack:"max,omitempty"`


### PR DESCRIPTION
## Description of the change

Just an example implementation of how we can provide different limits on certain fields. 
Keeping as a draft for now, but support on the front-end is already added. 

edit:
Here is a summary. The goal whenever expanding the schema is to prevent bloat that would be confusing, but also not to hide the location of fields or make it unnecessarily convoluted. The reason why I chose the below option compared to the alternatives was because of the consideration that minimally nested fields would provide a descriptive, multi-purpose, and organized structure to the schema while also not making the field location or names feel bloated as it would if flattening the new fields into the parent param. 
```
data_type: ...
label: ...
desc: ...
filters: { 
    // used for platform and sid and string types
    whitelist?: string[]
    blacklist?: string[]
    // used for numbers and dates
    min?: number
    max?: number
}
limits: { // used for numbers and dates
    min?: number
    max?: number
}
```
===
alternatives I considered but didn't use are:
```
data_type: ...
label: ...
desc: ...
platform_filters: { 
    // used for platform and sid types
    whitelist?: string[]
    blacklist?: string[]
}
limits: { // used for numbers and dates
    min?: number
    max?: number
}
```
or
```
data_type: ...
label: ...
desc: ...
platform_whitelist: string[]
platform_blacklist: string[]
num_min: number
num_max: number
}
```
