### PR TITLE
Get secret method

### DIFF
--- a/core/utils.go
+++ b/core/utils.go
@@ -13,7 +13,7 @@ var (
 	cacheMutex  sync.RWMutex
 )
 
-func usingSecretValue(key string, org *limacharlie.Organization, fn func(val string) error) error {
+func UsingSecretValue(key string, org *limacharlie.Organization, fn func(val string) error) error {
 	var err error
 	var apiKey string
 	var exists bool

--- a/core/utils.go
+++ b/core/utils.go
@@ -30,19 +30,22 @@ func usingSecretValue(key string, org *limacharlie.Organization, fn func(val str
 			// ensure to update local cache
 			setSecretCache(secretName, apiKey)
 		}
-	}
 
-	const maxRetries = 2
-	var lastError error
-	for i := 0; i < maxRetries; i++ {
-		err := fn(apiKey)
-		if err == nil {
-			return nil
+		const maxRetries = 2
+		for i := 0; i < maxRetries; i++ {
+			err = fn(apiKey)
+			if err == nil {
+				return nil
+			}
 		}
-		lastError = err
+		return fmt.Errorf("secrets function failed after %d attempts for org: %s err: %v", maxRetries, org.GetOID(), err)
 	}
 
-	return fmt.Errorf("secrets function failed after %d attempts for org: %s err: %v", maxRetries, org.GetOID(), lastError)
+	// no retry logic if actual key passed
+	if err := fn(apiKey); err != nil {
+		return err
+	}
+	return nil
 }
 
 func setSecretCache(secretName, apiKey string) {

--- a/core/utils.go
+++ b/core/utils.go
@@ -1,1 +1,77 @@
 package core
+
+import (
+	"fmt"
+	"github.com/refractionPOINT/go-limacharlie/limacharlie"
+	"path"
+	"strings"
+	"sync"
+)
+
+var (
+	SecretCache = make(map[string]string)
+	cacheMutex  sync.RWMutex
+)
+
+func usingSecretValue(key string, org *limacharlie.Organization, fn func(val string) error) error {
+	var err error
+	var apiKey string
+	var exists bool
+	if strings.Contains(key, "hive://") {
+		secretName := path.Base(key)
+		// Try to get secret from cache
+		apiKey, exists = getSecretFromCache(secretName)
+		if !exists {
+			apiKey, err = getSecretFromHive(secretName, org)
+			if err != nil {
+				return err
+			}
+
+			// ensure to update local cache
+			setSecretCache(secretName, apiKey)
+		}
+	}
+
+	const maxRetries = 2
+	var lastError error
+	for i := 0; i < maxRetries; i++ {
+		err := fn(apiKey)
+		if err == nil {
+			return nil
+		}
+		lastError = err
+	}
+
+	return fmt.Errorf("secrets function failed after %d attempts for org: %s err: %v", maxRetries, org.GetOID(), lastError)
+}
+
+func setSecretCache(secretName, apiKey string) {
+	cacheMutex.Lock()
+	SecretCache[secretName] = apiKey
+	cacheMutex.Unlock()
+}
+
+func getSecretFromCache(secretName string) (string, bool) {
+	cacheMutex.RLock()
+	val, exists := SecretCache[secretName]
+	cacheMutex.RUnlock()
+	return val, exists
+}
+
+func getSecretFromHive(recordName string, org *limacharlie.Organization) (string, error) {
+	hc := limacharlie.NewHiveClient(org)
+	data, err := hc.Get(limacharlie.HiveArgs{
+		HiveName:     "secret",
+		PartitionKey: org.GetOID(),
+		Key:          recordName,
+	})
+	if err != nil {
+		return "", err
+	}
+	value, ok := data.Data["secret"].(string)
+	if !ok || value == "" {
+		return "", fmt.Errorf("secret not set or is not of type string")
+	}
+
+	return data.Data["secret"].(string), nil
+}

--- a/core/utils.go
+++ b/core/utils.go
@@ -9,7 +9,7 @@ import (
 )
 
 var (
-	SecretCache = make(map[string]string)
+	secretCache = make(map[string]string)
 	cacheMutex  sync.RWMutex
 )
 
@@ -47,13 +47,13 @@ func usingSecretValue(key string, org *limacharlie.Organization, fn func(val str
 
 func setSecretCache(secretName, apiKey string) {
 	cacheMutex.Lock()
-	SecretCache[secretName] = apiKey
+	secretCache[secretName] = apiKey
 	cacheMutex.Unlock()
 }
 
 func getSecretFromCache(secretName string) (string, bool) {
 	cacheMutex.RLock()
-	val, exists := SecretCache[secretName]
+	val, exists := secretCache[secretName]
 	cacheMutex.RUnlock()
 	return val, exists
 }


### PR DESCRIPTION
## Description of the change

>  Get secret method will give extensions the ability to grab/set secret without running UseSecretValuel. @maximelb I  don't think passing two keys is  the solution if we want to keep the UseSecret method as generic as possible. We could maybe pass a slice or map to handle a dynamic size of keys to, but we could also just provide a method that allows a user to grab any number of secrets from hive/cache and build out there api request as needed from keys pulled from cache. 

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Fix [#1]() 

## Describe multi-tenancy segmentation

