### PR TITLE
handle case of nil interface on unmarshal struct

### DIFF
--- a/core/extension.go
+++ b/core/extension.go
@@ -210,6 +210,10 @@ func (e *Extension) generateSDK(oad common.OrgAccessData) (*limacharlie.Organiza
 }
 
 func unmarshalToStruct(d limacharlie.Dict, s interface{}) (interface{}, error) {
+	if s == nil {
+		return nil, fmt.Errorf("invalid request missing request struct definition")
+	}
+
 	// Create a new instance of the struct needed using reflection.
 	inCopyValue := reflect.ValueOf(s).Elem()
 	inCopy := reflect.New(inCopyValue.Type())


### PR DESCRIPTION
## Description of the change

> If request struct type is not set in extension handler, a panic will occur. This will handle and return error if no request struct definition is set.

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Fix [#1]() 

## Describe multi-tenancy segmentation

