### PR TITLE
Make the simplified frameworks do initial update async.

### DIFF
--- a/simplified/dr.go
+++ b/simplified/dr.go
@@ -125,13 +125,12 @@ func (l *RuleExtension) Init() (*core.Extension, error) {
 					return common.Response{Error: err.Error()}
 				}
 
-				// We also push the initial update.
-				resp := l.onInstall(ctx, org, nil, nil, "")
-				if resp.Error != "" {
-					return resp
-				}
-
-				return common.Response{}
+				// The initial update will be done asynchronously.
+				return common.Response{Continuations: []common.ContinuationRequest{{
+					InDelaySeconds: 1,
+					Action:         "update_rules",
+					State:          limacharlie.Dict{},
+				}}}
 			},
 			// An Org unsubscribed.
 			common.EventTypes.Unsubscribe: func(ctx context.Context, org *limacharlie.Organization, data, conf limacharlie.Dict, idempotentKey string) common.Response {

--- a/simplified/lookup.go
+++ b/simplified/lookup.go
@@ -95,13 +95,12 @@ func (l *LookupExtension) Init() (*core.Extension, error) {
 					return common.Response{Error: err.Error()}
 				}
 
-				// We also push the initial update.
-				resp := l.onUpdate(ctx, org, nil, nil, "", map[string]common.ResourceState{})
-				if resp.Error != "" {
-					return resp
-				}
-
-				return common.Response{}
+				// The initial update will be done asynchronously.
+				return common.Response{Continuations: []common.ContinuationRequest{{
+					InDelaySeconds: 1,
+					Action:         "update_lookup",
+					State:          limacharlie.Dict{},
+				}}}
 			},
 			// An Org unsubscribed.
 			common.EventTypes.Unsubscribe: func(ctx context.Context, org *limacharlie.Organization, data, conf limacharlie.Dict, idempotentKey string) common.Response {


### PR DESCRIPTION
## Description of the change

As discussed with Josh, moving the simplified frameworks to do the initial update (on subscription) async using a Continuation. This will make the Sub action very fast, and the filling of the rules async but immediately after.

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


