### PR TITLE
Avoid errors from users assuming hours.

### DIFF
--- a/simplified/dr.go
+++ b/simplified/dr.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -459,6 +460,12 @@ func addSuppression(rule limacharlie.Dict, suppressionTime string) limacharlie.D
 	rs := rrs.([]interface{})
 	if len(rs) == 0 {
 		return nil
+	}
+	// To avoid errors in prod from before the day where
+	// we validated the suppression time, we'll just
+	// just assume hours if the unit is not set.
+	if i, err := strconv.Atoi(suppressionTime); err == nil {
+		suppressionTime = fmt.Sprintf("%dh", i)
 	}
 	for _, r := range rs {
 		r, ok := r.(map[string]interface{})


### PR DESCRIPTION
## Description of the change

If the suppression time is just an int without units, just assume hours.

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

