### PR TITLE
Adding update event type and adding event handlers to SchemaRequestResp

### DIFF
--- a/common/messages.go
+++ b/common/messages.go
@@ -49,6 +49,7 @@ type SchemaRequestResponse struct {
 	Config         SchemaObject   `json:"config_schema" msgpack:"config_schema"`
 	Request        RequestSchemas `json:"request_schema" msgpack:"request_schema"`
 	RequiredEvents []EventName    `json:"required_events" msgpack:"required_events"`
+	EventHandlers  []EventName    `json:"event_handlers" msgpack:"event_handlers"`
 }
 
 // A set of org credentials the Extension can use.
@@ -114,7 +115,9 @@ type SensorUpdate struct {
 var EventTypes = struct {
 	Subscribe   EventName
 	Unsubscribe EventName
+	Update      EventName
 }{
 	Subscribe:   "subscribe",
 	Unsubscribe: "unsubscribe",
+	Update:      "update",
 }

--- a/common/messages.go
+++ b/common/messages.go
@@ -49,7 +49,6 @@ type SchemaRequestResponse struct {
 	Config         SchemaObject   `json:"config_schema" msgpack:"config_schema"`
 	Request        RequestSchemas `json:"request_schema" msgpack:"request_schema"`
 	RequiredEvents []EventName    `json:"required_events" msgpack:"required_events"`
-	EventHandlers  []EventName    `json:"event_handlers" msgpack:"event_handlers"`
 }
 
 // A set of org credentials the Extension can use.

--- a/core/extension.go
+++ b/core/extension.go
@@ -195,11 +195,18 @@ func (e *Extension) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			response = e.Callbacks.ValidateConfig(ctx, org, message.ConfigValidation.Config)
 		}
 	} else if message.SchemaRequest != nil {
+
+		eventHandlers := make([]common.EventName, 0)
+		for handler, _ := range e.Callbacks.EventHandlers {
+			eventHandlers = append(eventHandlers, handler)
+		}
+
 		response.Data = &common.SchemaRequestResponse{
 			Views:          e.ViewsSchema,
 			Config:         e.ConfigSchema,
 			Request:        e.RequestSchema,
 			RequiredEvents: e.RequiredEvents,
+			EventHandlers:  eventHandlers,
 		}
 	} else {
 		response.Error = fmt.Sprintf("no data in request: %s", requestData)

--- a/core/extension.go
+++ b/core/extension.go
@@ -205,8 +205,7 @@ func (e *Extension) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			Views:          e.ViewsSchema,
 			Config:         e.ConfigSchema,
 			Request:        e.RequestSchema,
-			RequiredEvents: e.RequiredEvents,
-			EventHandlers:  eventHandlers,
+			RequiredEvents: eventHandlers,
 		}
 	} else {
 		response.Error = fmt.Sprintf("no data in request: %s", requestData)


### PR DESCRIPTION


## Description of the change

> Adding update event type and adding event handlers to SchemaRequestResponse. We were not returning set event handlers in schema request call. I added a list of eventhandlers to determine what events are set on extension. This will be utilized in legion extension manager when determining if a update event needs to be sent. 

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Fix [#1]() 

## Describe multi-tenancy segmentation

