### PR TITLE
Support actions change

### DIFF
--- a/common/config_schema.go
+++ b/common/config_schema.go
@@ -50,6 +50,8 @@ type Validator = struct {
 	// for number and time/date data_types
 	Min int `json:"min,omitempty" msgpack:"min,omitempty"`
 	Max int `json:"max,omitempty" msgpack:"max,omitempty"`
+	// for platform and sid types
+	Platforms []string `json:"platforms,omitempty" msgpack:"platforms,omitempty"`
 }
 
 type ComplexEnumValues = struct {

--- a/common/config_schema.go
+++ b/common/config_schema.go
@@ -45,7 +45,7 @@ type Validator = struct {
 	// for events, string types (mutually exclusive)
 	WhiteList []string `json:"whitelist,omitempty" msgpack:"whitelist,omitempty"`
 	Blacklist []string `json:"blacklist,omitempty" msgpack:"blacklist,omitempty"`
-	// for string chars (mutually exclusive)
+	// for string types (mutually exclusive)
 	ValidRE   string `json:"valid_re,omitempty" msgpack:"valid_re,omitempty"`
 	InvalidRE string `json:"invalid_re,omitempty" msgpack:"invalid_re,omitempty"`
 	// for number and time/date data_types

--- a/common/config_schema.go
+++ b/common/config_schema.go
@@ -13,17 +13,6 @@ type SchemaObject struct {
 	ElementName        string `json:"element_name,omitempty" msgpack:"element_name,omitempty"`
 	ElementDescription string `json:"element_desc,omitempty" msgpack:"element_desc,omitempty"`
 
-	// legacy fields
-	// -------------------------------------------
-	RenderType      string         `json:"render_type,omitempty" msgpack:"render_type,omitempty"`
-	KeyDataType     SchemaDataType `json:"key_data_type,omitempty" msgpack:"key_data_type,omitempty"`
-	KeyName         string         `json:"key_name,omitempty" msgpack:"key_name,omitempty"`
-	KeyLabel        string         `json:"key_label,omitempty" msgpack:"key_label,omitempty"`
-	KeyDisplayIndex int            `json:"key_display_index,omitempty" msgpack:"key_display_index,omitempty"`
-
-	// Extended definition for Interactive elements
-	// like Configs and Requests.
-	// -------------------------------------------
 	// All field sets must be satisfied.
 	// Each field is specifies fields where one and only one must be set.
 	Requirements []RequiredFields `json:"requirements" msgpack:"requirements"`

--- a/common/config_schema.go
+++ b/common/config_schema.go
@@ -41,10 +41,8 @@ type RecordKey = struct {
 // Valid objects require one of the following fields to be specified.
 type RequiredFields = []SchemaKey
 
-// for sid and platforms data_type
 type Validator = struct {
-	// whitelist and blacklist are mutually exclusive
-	// for platforms, sid platforms, string chars
+	// for string chars (mutually exclusive)
 	ValidRE   string `json:"valid_re,omitempty" msgpack:"valid_re,omitempty"`
 	InvalidRE string `json:"invalid_re,omitempty" msgpack:"invalid_re,omitempty"`
 	// for number and time/date data_types

--- a/common/config_schema.go
+++ b/common/config_schema.go
@@ -42,6 +42,9 @@ type RecordKey = struct {
 type RequiredFields = []SchemaKey
 
 type Validator = struct {
+	// for events, string types (mutually exclusive)
+	WhiteList []string `json:"whitelist,omitempty" msgpack:"whitelist,omitempty"`
+	Blacklist []string `json:"blacklist,omitempty" msgpack:"blacklist,omitempty"`
 	// for string chars (mutually exclusive)
 	ValidRE   string `json:"valid_re,omitempty" msgpack:"valid_re,omitempty"`
 	InvalidRE string `json:"invalid_re,omitempty" msgpack:"invalid_re,omitempty"`

--- a/common/config_schema.go
+++ b/common/config_schema.go
@@ -80,15 +80,6 @@ type SchemaElement struct {
 	EnumValues        []interface{}       `json:"enum_values,omitempty" msgpack:"enum_values,omitempty"` // If the type is enum, these are the possible values.
 	ComplexEnumValues []ComplexEnumValues `json:"complex_enum_values,omitempty" msgpack:"complex_enum_values,omitempty"`
 	Filter            Validator           `json:"filter,omitempty" msgpack:"filter,omitempty"`
-
-	// Extended definition for Actionable elements
-	// like Configs and Responses.
-	// -------------------------------------------
-	// List of Requests that can be performed on the given
-	// element. Will translate into buttons on elements that
-	// will issue a Request to Extension with the element's
-	// data included.
-	SupportedActions []ActionName `json:"supported_actions,omitempty" msgpack:"supported_actions,omitempty"`
 }
 
 // Example of a config for something like a Sigma Extension.

--- a/common/request_schema.go
+++ b/common/request_schema.go
@@ -16,8 +16,15 @@ type StatusMessages struct {
 	ErrorMessage      string `json:"error,omitempty" msgpack:"error,omitempty"`
 }
 
-type ResponseSchema struct {
-	*SchemaObject
+type ResponseSchemaObject struct {
+	// extends a type SchemaObject
+	Fields map[SchemaKey]SchemaElement `json:"fields" msgpack:"fields"`
+	// If this element is a type "Record" object, field "key" defines the keys that own "Fields"
+	Key RecordKey `json:"key,omitempty" msgpack:"key,omitempty"`
+	// what to call each element in the record/list - use for auto generated copy/labels
+	ElementName        string `json:"element_name,omitempty" msgpack:"element_name,omitempty"`
+	ElementDescription string `json:"element_desc,omitempty" msgpack:"element_desc,omitempty"`
+
 	// List of Requests that can be performed on the given
 	// response data. Will translate into buttons on elements that
 	// will issue a Request to Extension with the element's data
@@ -26,15 +33,15 @@ type ResponseSchema struct {
 
 // Shema of expected Parameters for a specific request Action.
 type RequestSchema struct {
-	IsDefaultRequest     bool           `json:"is_default,omitempty" msgpack:"is_default,omitempty"` // Is the default Request when displaying the state of the Extension.
-	Label                Label          `json:"label,omitempty" msgpack:"label,omitempty"`           // (optional) Human friendly name for the request
-	IsUserFacing         bool           `json:"is_user_facing" msgpack:"is_user_facing"`             // Is this Action expected to be performed by a human, or is it for automation.
-	ShortDescription     string         `json:"short_description" msgpack:"short_description"`       // Short description of what this Action does.
-	LongDescription      string         `json:"long_description" msgpack:"long_description"`         // Longer version of the Short Description.
-	Messages             StatusMessages `json:"messages,omitempty" msgpack:"messages,omitempty"`     // (optional) Customizable text to inform the user
-	IsImpersonated       bool           `json:"is_impersonated" msgpack:"is_impersonated"`           // If true, this action requires a JWT token from a user that it will use to impersonate.
-	ParameterDefinitions SchemaObject   `json:"parameters" msgpack:"parameters"`                     // List of Parameter Names and their definition.
-	ResponseDefinition   ResponseSchema `json:"response" msgpack:"response"`                         // Schema of the expected Response.
+	IsDefaultRequest     bool                 `json:"is_default,omitempty" msgpack:"is_default,omitempty"` // Is the default Request when displaying the state of the Extension.
+	Label                Label                `json:"label,omitempty" msgpack:"label,omitempty"`           // (optional) Human friendly name for the request
+	IsUserFacing         bool                 `json:"is_user_facing" msgpack:"is_user_facing"`             // Is this Action expected to be performed by a human, or is it for automation.
+	ShortDescription     string               `json:"short_description" msgpack:"short_description"`       // Short description of what this Action does.
+	LongDescription      string               `json:"long_description" msgpack:"long_description"`         // Longer version of the Short Description.
+	Messages             StatusMessages       `json:"messages,omitempty" msgpack:"messages,omitempty"`     // (optional) Customizable text to inform the user
+	IsImpersonated       bool                 `json:"is_impersonated" msgpack:"is_impersonated"`           // If true, this action requires a JWT token from a user that it will use to impersonate.
+	ParameterDefinitions SchemaObject         `json:"parameters" msgpack:"parameters"`                     // List of Parameter Names and their definition.
+	ResponseDefinition   ResponseSchemaObject `json:"response" msgpack:"response"`                         // Schema of the expected Response.
 }
 
 // Strongly typed list of Parameter Data Types.

--- a/common/request_schema.go
+++ b/common/request_schema.go
@@ -16,6 +16,14 @@ type StatusMessages struct {
 	ErrorMessage      string `json:"error,omitempty" msgpack:"error,omitempty"`
 }
 
+type ResponseSchema struct {
+	*SchemaObject
+	// List of Requests that can be performed on the given
+	// response data. Will translate into buttons on elements that
+	// will issue a Request to Extension with the element's data
+	SupportedActions []ActionName `json:"supported_actions,omitempty" msgpack:"supported_actions,omitempty"`
+}
+
 // Shema of expected Parameters for a specific request Action.
 type RequestSchema struct {
 	IsDefaultRequest     bool           `json:"is_default,omitempty" msgpack:"is_default,omitempty"` // Is the default Request when displaying the state of the Extension.
@@ -26,7 +34,7 @@ type RequestSchema struct {
 	Messages             StatusMessages `json:"messages,omitempty" msgpack:"messages,omitempty"`     // (optional) Customizable text to inform the user
 	IsImpersonated       bool           `json:"is_impersonated" msgpack:"is_impersonated"`           // If true, this action requires a JWT token from a user that it will use to impersonate.
 	ParameterDefinitions SchemaObject   `json:"parameters" msgpack:"parameters"`                     // List of Parameter Names and their definition.
-	ResponseDefinition   *SchemaObject  `json:"response" msgpack:"response"`                         // Schema of the expected Response.
+	ResponseDefinition   ResponseSchema `json:"response" msgpack:"response"`                         // Schema of the expected Response.
 }
 
 // Strongly typed list of Parameter Data Types.

--- a/examples/basic/main.go
+++ b/examples/basic/main.go
@@ -51,7 +51,7 @@ func init() {
 							{"some_value"}, // The "some_value" parameter is required and has no alternative parameters.
 						},
 					},
-					ResponseDefinition: common.ResponseSchema{
+					ResponseDefinition: common.ResponseSchemaObject{
 						Fields: map[common.SchemaKey]common.SchemaElement{
 							"some_value": {
 								Description: "same value as received",

--- a/examples/basic/main.go
+++ b/examples/basic/main.go
@@ -51,13 +51,14 @@ func init() {
 							{"some_value"}, // The "some_value" parameter is required and has no alternative parameters.
 						},
 					},
-					ResponseDefinition: &common.SchemaObject{
+					ResponseDefinition: common.ResponseSchema{
 						Fields: map[common.SchemaKey]common.SchemaElement{
 							"some_value": {
 								Description: "same value as received",
 								DataType:    common.SchemaDataTypes.String,
 							},
 						},
+						SupportedActions: []string{},
 					},
 				},
 			},

--- a/python/lcextension/schema.py
+++ b/python/lcextension/schema.py
@@ -44,7 +44,6 @@ class SchemaElement(object):
         self.ObjectSchema = None # SchemaObject
         self.EnumValues = None # [] of string
         self.PlaceHolder = None
-        self.SupportedActions = None # [] of Action names
         self.Filter = {}
         for k, v in kwargs.items():
             if not hasattr(self, k):
@@ -62,7 +61,6 @@ class SchemaElement(object):
             'object' : None if self.ObjectSchema is None else self.ObjectSchema.serialize(),
             'enum_values' : self.EnumValues,
             'placeholder' : self.PlaceHolder,
-            'supported_actions' : self.SupportedActions,
             'filter': self.Filter,
         }
 

--- a/simplified/cli.go
+++ b/simplified/cli.go
@@ -115,7 +115,7 @@ func (l *CLIExtension) Init() (*core.Extension, error) {
 						},
 					},
 				},
-				ResponseDefinition: &common.SchemaObject{
+				ResponseDefinition: common.ResponseSchemaObject{
 					Fields: map[common.SchemaKey]common.SchemaElement{
 						"output_list": common.SchemaElement{
 							DataType:    common.SchemaDataTypes.Object,

--- a/simplified/dr.go
+++ b/simplified/dr.go
@@ -84,7 +84,7 @@ func (l *RuleExtension) Init() (*core.Extension, error) {
 				ShortDescription:     "update the rules",
 				IsImpersonated:       false,
 				ParameterDefinitions: common.SchemaObject{},
-				ResponseDefinition:   &common.SchemaObject{},
+				ResponseDefinition:   common.ResponseSchemaObject{},
 			},
 		},
 	}

--- a/simplified/lookup.go
+++ b/simplified/lookup.go
@@ -48,7 +48,7 @@ func (l *LookupExtension) Init() (*core.Extension, error) {
 				ShortDescription:     "update the lookup",
 				IsImpersonated:       false,
 				ParameterDefinitions: common.SchemaObject{},
-				ResponseDefinition:   &common.SchemaObject{},
+				ResponseDefinition:   common.ResponseSchemaObject{},
 			},
 		},
 	}


### PR DESCRIPTION
## Description of the change

Proposed change to simplify the way supported_actions are implemented.
This will reduce confusion with where the field should apply, and also simplifies the requests to work on the entire response data, and not just a subset.


P.S.
- I'm not sure if I updated schema.py properly
