### PR TITLE
adding optional field for FieldColumns

### DIFF
--- a/common/messages.go
+++ b/common/messages.go
@@ -40,6 +40,9 @@ type View struct {
 	Name            string   `json:"name" msgpack:"name"`
 	LayoutType      string   `json:"layout_type" msgpack:"layout_type"`
 	DefaultRequests []string `json:"default_requests" msgpack:"default_requests"`
+
+	// optional UI view settins: more exist on FE "LayoutOptions" but aren't all exposed via schema
+	FieldColumns int `json:"field_columns" msgpack:"field_columns"`
 }
 
 // A request to get the schema required by the Extension for its configuration and requests.


### PR DESCRIPTION
## Description of the change
The plan was always to reveal more optional fields into the extensions UI that a back-end developer could use as needed, and a field for number of columns seems like it would be relevant for git-sync.

@josh-lc could I ask you to sanity check that this simple commit will accurately allow for an optional field to be added onto all schemas? I don't want this field to ever show up as an empty value on the schema if it can be helped because I think that gives the impression that it needs a value and it really doesn't. 

For context, this field is typically auto-determined on the front-end and we would basically just be adding a field to the schema to override this value. 

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

Fix refractionPOINT/tracking#1
