### PR TITLE
Add support for execution timeout, improved logging

### DIFF
--- a/simplified/cli.go
+++ b/simplified/cli.go
@@ -365,11 +365,14 @@ func (e *CLIExtension) TryParsingOutput(output []byte) CLIReturnData {
 }
 
 func (e *CLIExtension) stopThisInstance(o *limacharlie.Organization, request *CLIRunRequest) {
-	e.Logger.Info(fmt.Sprintf("stopping instance after processing request for oid=%s,tool=%s", o.GetOID(), request.Tool))
+	e.Logger.Info(fmt.Sprintf("stopping instance after processing request for oid %s and tool %s", o.GetOID(), request.Tool))
 	p, err := os.FindProcess(os.Getpid())
 	if err != nil {
 		e.Logger.Error(fmt.Sprintf("failed to find process: %v", err))
 		return
 	}
 	p.Signal(syscall.SIGTERM)
+
+	// TODO: Should we add a safe guard and send SIGKILL if process is still alive after
+	// X seconds?
 }

--- a/simplified/cli.go
+++ b/simplified/cli.go
@@ -54,7 +54,7 @@ type CLIRunRequest struct {
 var errUnknownTool = errors.New("unknown tool")
 
 // Timeout for CLI command execution
-const toolCommandExecutionTimeout = 120 * time.Second
+const toolCommandExecutionTimeout = 9 * time.Minute
 
 // Maximum size / length for the CLI arguments in bytes
 const commandArgumentsMaxSize = 1024 * 10

--- a/simplified/cli.go
+++ b/simplified/cli.go
@@ -229,7 +229,7 @@ func (e *CLIExtension) doRun(o *limacharlie.Organization, request *CLIRunRequest
 	// The service is set to let one request at a time and we
 	// will also terminate the container on exit by sending
 	// outselves a signal to terminate.
-	defer stopThisInstance()
+	defer e.stopThisInstance(o, request)
 
 	// If a full Command Line was provided in the request
 	// instead of tokens, use shlex to parse it into tokens.
@@ -325,9 +325,11 @@ func (e *CLIExtension) TryParsingOutput(output []byte) CLIReturnData {
 	return CLIReturnData{OutputString: string(output)}
 }
 
-func stopThisInstance() {
+func (e *CLIExtension) stopThisInstance(o *limacharlie.Organization, request *CLIRunRequest) {
+	e.Logger.Info(fmt.Sprintf("stopping instance after processing request for oid=%s,tool=%s", o.GetOID(), request.Tool))
 	p, err := os.FindProcess(os.Getpid())
 	if err != nil {
+		e.Logger.Error(fmt.Sprintf("failed to find process: %v", err))
 		return
 	}
 	p.Signal(syscall.SIGTERM)


### PR DESCRIPTION
## Description

This pull request adds support for a timeout when executing CLI tool commands.

Additionally it also improves some logging to make troubleshooting easier.

## Notes

All the extensions using this abstraction will need to be updated to accept `ctx` argument and handle it appropriately.

## Type of change

- [x] New feature (non-breaking change that adds functionality)

## Related issues

Part of refractionPOINT/tracking#3122