### PR TITLE
Add additional logging to doRun to make troubleshooting easier

### DIFF
--- a/simplified/cli.go
+++ b/simplified/cli.go
@@ -248,6 +248,7 @@ func (e *CLIExtension) doRun(o *limacharlie.Organization, request *CLIRunRequest
 	if len(request.CommandTokens) == 0 && len(request.CommandLine) != 0 {
 		tokens, err := shlex.Split(request.CommandLine)
 		if err != nil {
+			e.Logger.Info(fmt.Sprintf("failed to parse command line for %s and tool %s: %v", o.GetOID(), request.Tool, err))
 			return common.Response{
 				Error: fmt.Sprintf("failed to parse command line: %v", err),
 			}
@@ -256,12 +257,14 @@ func (e *CLIExtension) doRun(o *limacharlie.Organization, request *CLIRunRequest
 	}
 
 	if len(request.CommandLine) > commandArgumentsMaxSize {
+		e.Logger.Info(fmt.Sprintf("command line is too long for %s and tool %s, got %d, max size is %d", o.GetOID(), request.Tool, len(request.CommandLine), commandArgumentsMaxSize))
 		return common.Response{
 			Error: fmt.Sprintf("command line is too long, max size is %d bytes", commandArgumentsMaxSize),
 		}
 	}
 
 	if len(request.CommandTokens) > commandArgumentsMaxCount {
+		e.Logger.Info(fmt.Sprintf("command arguments are too long for %s and tool %s, got %d, max count is %d", o.GetOID(), request.Tool, len(request.CommandTokens), commandArgumentsMaxCount))
 		return common.Response{
 			Error: fmt.Sprintf("command arguments are too long, max count is %d", commandArgumentsMaxCount),
 		}
@@ -278,6 +281,7 @@ func (e *CLIExtension) doRun(o *limacharlie.Organization, request *CLIRunRequest
 		var ok bool
 		handler, ok = e.Descriptors[request.Tool]
 		if !ok {
+			e.Logger.Info(fmt.Sprintf("unknown tool for %s: %s", o.GetOID(), request.Tool))
 			return common.Response{
 				Error: fmt.Sprintf("unknown tool: %s", request.Tool),
 			}

--- a/simplified/cli.go
+++ b/simplified/cli.go
@@ -390,7 +390,12 @@ func (e *CLIExtension) stopThisInstance(o *limacharlie.Organization, request *CL
 		e.Logger.Error(fmt.Sprintf("failed to find process: %v", err))
 		return
 	}
-	p.Signal(syscall.SIGTERM)
+
+	// Send SIGTERM to the current process.
+	if err := p.Signal(syscall.SIGTERM); err != nil {
+		e.Logger.Error(fmt.Sprintf("failed to send SIGTERM: %v", err))
+		return
+	}
 
 	// TODO: Should we add a safe guard and send SIGKILL if process is still alive after
 	// X seconds?


### PR DESCRIPTION
## Description

This is a small addition on top of https://github.com/refractionPOINT/lc-extension/pull/133.

It adds additional logging to make debugging and troubleshooting CLI extension requests easier.

## Type of change

- [x] New feature (non-breaking change that adds functionality)

## Related issues

Part of refractionPOINT/tracking#3122