### PR TITLE
Improve Error Handling: Explicitly Mark Retriable Errors and Avoid Unnecessary Retries

### DIFF
--- a/.github/workflows/code-quality.yaml
+++ b/.github/workflows/code-quality.yaml
@@ -1,0 +1,89 @@
+name: Code Quality
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+
+permissions:
+  contents: read  # for actions/checkout to fetch code
+  pull-requests: read  # needed for golangci-lint and only-new-issues option
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  lint:
+    name: Code Quality
+    runs-on: ubuntu-latest
+    timeout-minutes: 8
+
+    steps:
+      - uses: actions/checkout@master
+        with:
+          fetch-depth: 1
+
+      - name: Use Go ${{ matrix.go_version }}
+        uses: actions/setup-go@v5
+        with:
+          go-version: "1.23"
+
+      - name: Install Go Modules
+        run: |
+          go mod download
+
+      - name: Run Lint
+        run: |
+          test -z "$(go fmt ./...)" || (echo "Code needs formatting, run go fmt ./..." && exit 1)
+
+      - name: Run golangci-lint
+        uses: golangci/golangci-lint-action@e60da84bfae8c7920a47be973d75e15710aa8bd7  # v6.3.0
+        with:
+          version: v1.64.8
+          # There are existing issues in the code which haven't been fixed yet so for now, only report new issues
+          only-new-issues: true
+
+  unit_tests:
+    name: Unit Tests (Go ${{ matrix.go_version }})
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 10
+
+    strategy:
+      fail-fast: false
+      matrix:
+        go_version:
+          - "1.21"
+          - "1.22"
+          - "1.23"
+        os:
+          - ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@master
+        with:
+          fetch-depth: 1
+
+      - name: Use Go ${{ matrix.go_version }}
+        uses: actions/setup-go@v5
+        with:
+          go-version: ${{ matrix.go_version }}
+
+      - name: Install Go Modules
+        run: |
+          go mod download
+
+      - name: Run Unit Tests
+        run: |
+          mkdir -p .coverage/unit
+          go test ./... -race -v -cover -args -test.gocoverdir="$PWD/.coverage/unit"
+          go tool covdata percent -i=./.coverage/unit
+
+      - name: Upload Coverage Report
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-report-${{ matrix.go_version }}
+          path: .coverage/

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@
 
 # Output of the go coverage tool, specifically when used with LiteIDE
 *.out
+.coverage
 
 # Dependency directories (remove the comment below to include it)
 # vendor/

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -6,7 +6,6 @@ linters:
     - revive         # More configurable and faster than golint
     - gofumpt        # Enforces stricter formatting (better than gofmt)
     - gocritic       # Finds performance and style issues
-    - unparam        # Detects unused function parameters
     - misspell       # Detects spelling mistakes in code
     - gosec          # Static security analysis (e.g., detecting `hardcoded secrets`)
     - ineffassign    # Detects ineffectual assignments
@@ -16,9 +15,9 @@ linters:
 
 linters-settings:
   revive:
-    disable-all: false  # Ensure this is false to selectively disable rules
-    disabled-rules:
-      - dot-imports
+    rules:
+      - name: unused-parameter
+        disabled: true
   gocritic:
     disabled-checks:
       - ifElseChain # Disables the warning globally

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,24 @@
+linters:
+  enable:
+    - govet          # Catches logical errors (e.g., nil dereferences)
+    - staticcheck    # Finds unused variables, deprecated functions, etc.
+    - errcheck       # Ensures errors are properly handled
+    - revive         # More configurable and faster than golint
+    - gofumpt        # Enforces stricter formatting (better than gofmt)
+    - gocritic       # Finds performance and style issues
+    - unparam        # Detects unused function parameters
+    - misspell       # Detects spelling mistakes in code
+    - gosec          # Static security analysis (e.g., detecting `hardcoded secrets`)
+    - ineffassign    # Detects ineffectual assignments
+    - goconst        # Detects repeated strings that could be replaced by a constant
+    - prealloc       # Detects slice declarations that could potentially be preallocated
+    - gochecknoinits # Detects package-level variable initializations
+
+linters-settings:
+  revive:
+    disable-all: false  # Ensure this is false to selectively disable rules
+    disabled-rules:
+      - dot-imports
+  gocritic:
+    disabled-checks:
+      - ifElseChain # Disables the warning globally

--- a/common/config_schema.go
+++ b/common/config_schema.go
@@ -87,7 +87,7 @@ type SchemaElement struct {
 // 	},
 // 	"suppression": {
 // 		"description": "suppression configurations",
-// 		"is_requried": false,
+// 		"is_required": false,
 // 		"data_type": "object",
 // 		"display_index": 1,
 // 		"object": {

--- a/common/messages.go
+++ b/common/messages.go
@@ -18,8 +18,10 @@ type Message struct {
 }
 
 // Recurring messages used by LimaCharlie to see if an Extension is still available.
-type HeartBeatMessage struct{}
-type HeartBeatResponse struct{}
+type (
+	HeartBeatMessage  struct{}
+	HeartBeatResponse struct{}
+)
 
 // Message indicating an error LimaCharlie encountered.
 type ErrorReportMessage struct {
@@ -43,13 +45,15 @@ type View struct {
 }
 
 // A request to get the schema required by the Extension for its configuration and requests.
-type SchemaRequestMessage struct{}
-type SchemaRequestResponse struct {
-	Views          []View         `json:"views,omitempty" msgpack:"views,omitempty"`
-	Config         SchemaObject   `json:"config_schema" msgpack:"config_schema"`
-	Request        RequestSchemas `json:"request_schema" msgpack:"request_schema"`
-	RequiredEvents []EventName    `json:"required_events" msgpack:"required_events"`
-}
+type (
+	SchemaRequestMessage  struct{}
+	SchemaRequestResponse struct {
+		Views          []View         `json:"views,omitempty" msgpack:"views,omitempty"`
+		Config         SchemaObject   `json:"config_schema" msgpack:"config_schema"`
+		Request        RequestSchemas `json:"request_schema" msgpack:"request_schema"`
+		RequiredEvents []EventName    `json:"required_events" msgpack:"required_events"`
+	}
+)
 
 // A set of org credentials the Extension can use.
 type OrgAccessData struct {

--- a/common/messages.go
+++ b/common/messages.go
@@ -93,11 +93,22 @@ type EventMessage struct {
 // Format of responses from an Extension webhook.
 type Response struct {
 	Error             string                `json:"error" msgpack:"error"`
+	Retriable         *bool                 `json:"retriable,omitempty" msgpack:"retriable,omitempty"` // True if this error is retriable. This only applies to Responses where Error field is set. If not provided, every Response with Error set is considered to be retriable.
 	Version           uint64                `json:"version" msgpack:"version"`
 	Data              interface{}           `json:"data,omitempty" msgpack:"data,omitempty"`
 	SensorStateChange *SensorUpdate         `json:"ssc,omitempty" msgpack:"ssc,omitempty"` // For internal use only.
 	Continuations     []ContinuationRequest `json:"continuations,omitempty" msgpack:"continuations,omitempty"`
 	Metrics           *MetricReport         `json:"metrics,omitempty" msgpack:"metrics,omitempty"`
+}
+
+// Retriable returns true if Reiable field is either not provided (nil) or explicitly set to true.
+// This is needed for backward compatibility reasons - for now, we want to retry every request
+// which either has Retriable set to true or does not have this field set at all.
+func (r *Response) IsRetriable() bool {
+	if r.Retriable == nil {
+		return true
+	}
+	return *r.Retriable
 }
 
 type EventName = string

--- a/core/extension.go
+++ b/core/extension.go
@@ -224,6 +224,14 @@ func (e *Extension) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if response.Error != "" {
+		// TODO: In the future we should support more detailed error handling and error types such as
+		// validation error, etc. and return appropriate status code (e.g. 400 for validation error, etc.)
+		// For the time being we return 503 for retryable errors and 500 for non-retryable errors.
+		if response.IsRetriable() {
+			e.respondAndLog(w, http.StatusServiceUnavailable, &response)
+			return
+		}
+
 		e.respondAndLog(w, http.StatusInternalServerError, &response)
 		return
 	}

--- a/core/utils.go
+++ b/core/utils.go
@@ -2,10 +2,11 @@ package core
 
 import (
 	"fmt"
-	"github.com/refractionPOINT/go-limacharlie/limacharlie"
 	"path"
 	"strings"
 	"sync"
+
+	"github.com/refractionPOINT/go-limacharlie/limacharlie"
 )
 
 var (
@@ -111,4 +112,24 @@ func getSecretFromHive(recordName string, org *limacharlie.Organization) (string
 	}
 
 	return data.Data["secret"].(string), nil
+}
+
+// MaskSecrets replaces every occurrence of each secret in the text with a redacted message.
+// text: the text to mask secrets in
+// secrets: the list of secrets to mask
+func MaskSecrets(text string, secrets []string) string {
+	maskedText := text
+	for _, secret := range secrets {
+		maskedText = strings.ReplaceAll(maskedText, secret, "**** REDACTED ***")
+	}
+	return maskedText
+}
+
+// maskSecretsInSlice recursively masks secrets in a slice of strings.
+func MaskSecretsInSlice(texts []string, secrets []string) []string {
+	maskedTexts := make([]string, len(texts))
+	for i, text := range texts {
+		maskedTexts[i] = MaskSecrets(text, secrets)
+	}
+	return maskedTexts
 }

--- a/core/utils_test.go
+++ b/core/utils_test.go
@@ -1,0 +1,119 @@
+package core
+
+import "testing"
+
+func TestMaskSecrets(t *testing.T) {
+	tests := []struct {
+		name     string
+		text     string
+		secrets  []string
+		expected string
+	}{
+		{
+			name:     "single secret",
+			text:     "password=1234",
+			secrets:  []string{"1234"},
+			expected: "password=**** REDACTED ***",
+		},
+		{
+			name:     "multiple secrets",
+			text:     "password=1234, token=abcd",
+			secrets:  []string{"1234", "abcd"},
+			expected: "password=**** REDACTED ***, token=**** REDACTED ***",
+		},
+		{
+			name:     "secret not found",
+			text:     "nothing here",
+			secrets:  []string{"secret"},
+			expected: "nothing here",
+		},
+		{
+			name:     "empty secrets slice",
+			text:     "password=1234",
+			secrets:  []string{},
+			expected: "password=1234",
+		},
+		{
+			name:     "multiple occurrences",
+			text:     "key=abcd, another key=abcd",
+			secrets:  []string{"abcd"},
+			expected: "key=**** REDACTED ***, another key=**** REDACTED ***",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := MaskSecrets(tt.text, tt.secrets)
+			if result != tt.expected {
+				t.Errorf("MaskSecrets() = %q; want %q", result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestMaskSecretsInSlice(t *testing.T) {
+	tests := []struct {
+		name     string
+		texts    []string
+		secrets  []string
+		expected []string
+	}{
+		{
+			name:     "single secret",
+			texts:    []string{"password=1234"},
+			secrets:  []string{"1234"},
+			expected: []string{"password=**** REDACTED ***"},
+		},
+		{
+			name:     "multiple secrets",
+			texts:    []string{"password=1234, token=abcd"},
+			secrets:  []string{"1234", "abcd"},
+			expected: []string{"password=**** REDACTED ***, token=**** REDACTED ***"},
+		},
+		{
+			name:     "secret not found",
+			texts:    []string{"nothing here"},
+			secrets:  []string{"secret"},
+			expected: []string{"nothing here"},
+		},
+		{
+			name:     "empty secrets slice",
+			texts:    []string{"password=1234"},
+			secrets:  []string{},
+			expected: []string{"password=1234"},
+		},
+		{
+			name:     "multiple occurrences",
+			texts:    []string{"key=abcd, another key=abcd"},
+			secrets:  []string{"abcd"},
+			expected: []string{"key=**** REDACTED ***, another key=**** REDACTED ***"},
+		},
+		{
+			name:     "multiple lines",
+			texts:    []string{"password=1234", "token=abcd"},
+			secrets:  []string{"1234", "abcd"},
+			expected: []string{"password=**** REDACTED ***", "token=**** REDACTED ***"},
+		},
+		{
+			name:     "empty input slice",
+			texts:    []string{},
+			secrets:  []string{"1234"},
+			expected: []string{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := MaskSecretsInSlice(tt.texts, tt.secrets)
+			if len(result) != len(tt.expected) {
+				t.Errorf("MaskSecretsInSlice() length = %d; want %d", len(result), len(tt.expected))
+				return
+			}
+			for i := range result {
+				if result[i] != tt.expected[i] {
+					t.Errorf("MaskSecretsInSlice()[%d] = %q; want %q", i, result[i], tt.expected[i])
+				}
+			}
+		})
+	}
+}

--- a/server/webserver/server.go
+++ b/server/webserver/server.go
@@ -23,8 +23,9 @@ func RunExtension(extension http.Handler) {
 		port = int(p)
 	}
 	srv := &http.Server{
-		Addr:    fmt.Sprintf(":%d", port),
-		Handler: extension,
+		Addr:              fmt.Sprintf(":%d", port),
+		Handler:           extension,
+		ReadHeaderTimeout: 5 * time.Second,
 	}
 
 	wgServerClosed := sync.WaitGroup{}

--- a/server/webserver/server.go
+++ b/server/webserver/server.go
@@ -3,12 +3,14 @@ package webserver
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"net/http"
 	"os"
 	"os/signal"
 	"strconv"
 	"sync"
 	"syscall"
+	"time"
 )
 
 func RunExtension(extension http.Handler) {
@@ -34,19 +36,32 @@ func RunExtension(extension http.Handler) {
 	go func() {
 		defer wgServerClosed.Done()
 		if err := srv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
-			os.Stderr.Write([]byte(fmt.Sprintf("http.ListenAndServe(): %v\n", err)))
+			slog.Error(fmt.Sprintf("http.ListenAndServe(): %v\n", err))
 
 			// Try to terminat the process cleanly.
 			p, err := os.FindProcess(os.Getpid())
 			if err != nil {
 				panic(err)
 			}
-			p.Signal(syscall.SIGTERM)
+			if err := p.Signal(syscall.SIGTERM); err != nil {
+				slog.Error(fmt.Sprintf("failed to send SIGTERM: %v", err))
+				return
+			}
 		}
 	}()
 
-	<-osSignals
-	srv.Shutdown(context.Background())
+	slog.Info(fmt.Sprintf("server is listening on port %d", port))
+
+	sig := <-osSignals
+	slog.Info(fmt.Sprintf("Received signal %v, shutting down server...\n", sig))
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	if err := srv.Shutdown(ctx); err != nil {
+		slog.Info(fmt.Sprintf("server.Shutdown(): %v\n", err))
+	}
+
+	slog.Info("server gracefully shut down")
 
 	wgServerClosed.Wait()
 }

--- a/simplified/cli.go
+++ b/simplified/cli.go
@@ -140,21 +140,21 @@ func (e *CLIExtension) Init() (*core.Extension, error) {
 				ParameterDefinitions: common.SchemaObject{
 					Requirements: requiredFields,
 					Fields: map[common.SchemaKey]common.SchemaElement{
-						"command_line": common.SchemaElement{
+						"command_line": {
 							DataType:     common.SchemaDataTypes.String,
 							Label:        "Command Line",
 							Description:  "The command to run.",
 							IsList:       false,
 							DisplayIndex: 3,
 						},
-						"command_tokens": common.SchemaElement{
+						"command_tokens": {
 							DataType:     common.SchemaDataTypes.String,
 							Label:        "Command Parameters",
 							Description:  "The command parameters to run as a tokenized list.",
 							IsList:       true,
 							DisplayIndex: 4,
 						},
-						"credentials": common.SchemaElement{
+						"credentials": {
 							DataType:     common.SchemaDataTypes.Secret,
 							Label:        "Credentials",
 							Description:  `The credentials to use for the command. A GCP JSON key, a DigitalOcean Access Token or an AWS "accessKeyID/secretAccessKey" pair.`,
@@ -164,24 +164,24 @@ func (e *CLIExtension) Init() (*core.Extension, error) {
 				},
 				ResponseDefinition: &common.SchemaObject{
 					Fields: map[common.SchemaKey]common.SchemaElement{
-						"output_list": common.SchemaElement{
+						"output_list": {
 							DataType:    common.SchemaDataTypes.Object,
 							Label:       "Outputs",
 							Description: "The output JSON objects of the command.",
 							IsList:      true,
 						},
-						"output_dict": common.SchemaElement{
+						"output_dict": {
 							DataType:    common.SchemaDataTypes.Object,
 							Label:       "Output",
 							Description: "The output JSON object of the command.",
 							IsList:      false,
 						},
-						"output_string": common.SchemaElement{
+						"output_string": {
 							DataType:    common.SchemaDataTypes.String,
 							Label:       "Raw Output",
 							Description: "The non-JSON output of the command.",
 						},
-						"status_code": common.SchemaElement{
+						"status_code": {
 							DataType:    common.SchemaDataTypes.Integer,
 							Label:       "Status Code",
 							Description: "The status of the command.",
@@ -374,7 +374,7 @@ func (e *CLIExtension) doRun(o *limacharlie.Organization, request *CLIRunRequest
 
 	if err != nil {
 		// For the time being, we retry all other errors exception context timeout + canceled.
-		var isRetriable = true
+		isRetriable := true
 
 		if errors.Is(err, context.DeadlineExceeded) {
 			isRetriable = false

--- a/simplified/cli.go
+++ b/simplified/cli.go
@@ -52,6 +52,7 @@ type CLIRunRequest struct {
 }
 
 var errUnknownTool = errors.New("unknown tool")
+var ErrInvalidCredentials = errors.New("invalid credentials")
 
 // Timeout for CLI command execution
 const toolCommandExecutionTimeout = 9 * time.Minute
@@ -373,12 +374,14 @@ func (e *CLIExtension) doRun(o *limacharlie.Organization, request *CLIRunRequest
 	}
 
 	if err != nil {
-		// For the time being, we retry all other errors exception context timeout + canceled.
+		// For the time being, we retry all other errors exception context timeout, canceled and invalid credentials.
 		isRetriable := true
 
 		if errors.Is(err, context.DeadlineExceeded) {
 			isRetriable = false
 		} else if errors.Is(err, context.Canceled) {
+			isRetriable = false
+		} else if errors.Is(err, ErrInvalidCredentials) {
 			isRetriable = false
 		}
 

--- a/simplified/cli.go
+++ b/simplified/cli.go
@@ -62,12 +62,12 @@ const commandArgumentsMaxSize = 1024 * 10
 // Maximum number of items for CLI arguments when specified as a list / parsing string argument to a list
 const commandArgumentsMaxCount = 50
 
-// Default implementation of SendToWebhookAdapterFunc. Only to be overriden by tests.
+// Default implementation of SendToWebhookAdapterFunc. Only to be overridden by tests.
 var sendToWebhookAdapterFunc = func(ext *core.Extension, o *limacharlie.Organization, hook limacharlie.Dict) error {
 	return ext.SendToWebhookAdapter(o, hook)
 }
 
-// Default implementation of stopThisInstance. Only to be overriden by tests.
+// Default implementation of stopThisInstance. Only to be overridden by tests.
 var stopThisInstanceFunc = func(logger limacharlie.LCLogger, o *limacharlie.Organization, request *CLIRunRequest, error string) {
 	if error == "" {
 		logger.Info(fmt.Sprintf("stopping instance after successful processing for oid %s and tool %s", o.GetOID(), request.Tool))

--- a/simplified/cli.go
+++ b/simplified/cli.go
@@ -342,8 +342,8 @@ func (e *CLIExtension) doRun(o *limacharlie.Organization, request *CLIRunRequest
 	// Log to the adapter.
 	anonReq := *request
 	anonReq.Credentials = "REDACTED"
-	// NOTE(Tomaz): request.CommandLine and request.CommandTokens could potentially also contain sensitive information
-	// so perhaps we should try to sanitize / mask it as well
+	anonReq.CommandLine = core.MaskSecrets(request.CommandLine, []string{request.Credentials})
+	anonReq.CommandTokens = core.MaskSecretsInSlice(request.CommandTokens, []string{request.Credentials})
 
 	hook := limacharlie.Dict{
 		"action":  "run",

--- a/simplified/cli_test.go
+++ b/simplified/cli_test.go
@@ -1,4 +1,3 @@
-//nolint:unparam
 package simplified
 
 import (

--- a/simplified/cli_test.go
+++ b/simplified/cli_test.go
@@ -96,17 +96,32 @@ func TestDoRun_ErrorHandling(t *testing.T) {
 	}
 	log := dummyLogger{}
 
+	assertCommonHandlerArguments := func(ctx context.Context, tokens []string, creds string) {
+		if ctx == nil {
+			t.Errorf("expected context to be non-nil")
+		}
+		if len(tokens) == 0 {
+			t.Errorf("expected tokens to be non-empty")
+		}
+		if creds == "" {
+			t.Errorf("expected creds to be non-empty")
+		}
+	}
 	// Dummy CLIHandlers to simulate different error conditions.
 	dummyHandlerSuccess := func(ctx context.Context, tokens []string, creds string) (CLIReturnData, error) {
+		assertCommonHandlerArguments(ctx, tokens, creds)
 		return CLIReturnData{OutputString: "success"}, nil
 	}
 	dummyHandlerDeadline := func(ctx context.Context, tokens []string, creds string) (CLIReturnData, error) {
+		assertCommonHandlerArguments(ctx, tokens, creds)
 		return CLIReturnData{}, context.DeadlineExceeded
 	}
 	dummyHandlerCanceled := func(ctx context.Context, tokens []string, creds string) (CLIReturnData, error) {
+		assertCommonHandlerArguments(ctx, tokens, creds)
 		return CLIReturnData{}, context.Canceled
 	}
 	dummyHandlerGeneric := func(ctx context.Context, tokens []string, creds string) (CLIReturnData, error) {
+		assertCommonHandlerArguments(ctx, tokens, creds)
 		return CLIReturnData{}, errors.New("generic error")
 	}
 

--- a/simplified/cli_test.go
+++ b/simplified/cli_test.go
@@ -1,0 +1,228 @@
+package simplified
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/refractionPOINT/go-limacharlie/limacharlie"
+	"github.com/refractionPOINT/lc-extension/core"
+)
+
+// dummyLogger is a minimal implementation of limacharlie.LCLogger.
+type dummyLogger struct{}
+
+func (d dummyLogger) Info(msg string)  {}
+func (d dummyLogger) Error(msg string) {}
+func (d dummyLogger) Debug(msg string) {}
+func (d dummyLogger) Warn(msg string)  {}
+func (d dummyLogger) Fatal(msg string) {}
+func (d dummyLogger) Trace(msg string) {}
+
+// dummyClientOptions holds minimal options to satisfy the client requirements.
+var dummyOpt = limacharlie.ClientOptions{
+	OID: "572d1b12-158c-4b86-87cd-554850b346cd",
+}
+
+var dummyCoreExt = &core.Extension{
+	ExtensionName: "dummy",
+	SecretKey:     "dummy",
+}
+
+func TestDoRun_ErrorHandling(t *testing.T) {
+	// Create a dummy organization and logger.
+	org, err := limacharlie.NewOrganizationFromClientOptions(dummyOpt, dummyLogger{})
+	if err != nil {
+		t.Fatalf("failed to create organization: %v", err)
+	}
+	log := dummyLogger{}
+
+	// Dummy CLIHandlers to simulate different error conditions.
+	dummyHandlerSuccess := func(ctx context.Context, tokens []string, creds string) (CLIReturnData, error) {
+		return CLIReturnData{OutputString: "success"}, nil
+	}
+	dummyHandlerDeadline := func(ctx context.Context, tokens []string, creds string) (CLIReturnData, error) {
+		return CLIReturnData{}, context.DeadlineExceeded
+	}
+	dummyHandlerCanceled := func(ctx context.Context, tokens []string, creds string) (CLIReturnData, error) {
+		return CLIReturnData{}, context.Canceled
+	}
+	dummyHandlerGeneric := func(ctx context.Context, tokens []string, creds string) (CLIReturnData, error) {
+		return CLIReturnData{}, errors.New("generic error")
+	}
+
+	// Start with a CLIExtension that has one descriptor ("dummy").
+	cliExt := &CLIExtension{
+		Name:                        "test-extension",
+		SecretKey:                   "secret",
+		Logger:                      log,
+		Descriptors:                 map[CLIName]CLIDescriptor{"dummy": {ProcessCommand: dummyHandlerSuccess, CredentialsFormat: "", ExampleCommand: "dummy"}},
+		DisableStop:                 true,
+		DisableSendToWebhookAdapter: true,
+	}
+
+	// Test case: invalid command line (shlex.Split error).
+	t.Run("invalid command line", func(t *testing.T) {
+		// An unmatched quote should cause shlex.Split to return an error.
+		req := &CLIRunRequest{
+			CommandLine:   `echo "unmatched quote`,
+			CommandTokens: []string{},
+			Credentials:   "creds",
+			Tool:          "dummy",
+		}
+		resp := cliExt.doRun(org, req, "ident", "inv")
+		if !strings.Contains(resp.Error, "failed to parse command line") {
+			t.Errorf("expected parse error, got: %s", resp.Error)
+		}
+		if resp.Retriable == nil || *resp.Retriable {
+			t.Errorf("expected retriable to be false")
+		}
+	})
+
+	// Test case: command line too long.
+	t.Run("command line too long", func(t *testing.T) {
+		longCmd := strings.Repeat("a", commandArgumentsMaxSize+1)
+		req := &CLIRunRequest{
+			CommandLine:   longCmd,
+			CommandTokens: []string{},
+			Credentials:   "creds",
+			Tool:          "dummy",
+		}
+		resp := cliExt.doRun(org, req, "ident", "inv")
+		expected := fmt.Sprintf("command line is too long, max size is %d bytes", commandArgumentsMaxSize)
+		if resp.Error != expected {
+			t.Errorf("expected error: %s, got: %s", expected, resp.Error)
+		}
+		if resp.Retriable == nil || *resp.Retriable {
+			t.Errorf("expected retriable to be false")
+		}
+	})
+
+	// Test case: command tokens too many.
+	t.Run("command tokens too many", func(t *testing.T) {
+		tokens := make([]string, commandArgumentsMaxCount+1)
+		req := &CLIRunRequest{
+			CommandLine:   "",
+			CommandTokens: tokens,
+			Credentials:   "creds",
+			Tool:          "dummy",
+		}
+		resp := cliExt.doRun(org, req, "ident", "inv")
+		expected := fmt.Sprintf("command arguments are too long, max count is %d", commandArgumentsMaxCount)
+		if resp.Error != expected {
+			t.Errorf("expected error: %s, got: %s", expected, resp.Error)
+		}
+		if resp.Retriable == nil || *resp.Retriable {
+			t.Errorf("expected retriable to be false")
+		}
+	})
+
+	// Test case: unknown tool.
+	t.Run("unknown tool", func(t *testing.T) {
+		// Create a CLIExtension with multiple tools.
+		cliExtMulti := &CLIExtension{
+			Name:      "test-extension",
+			SecretKey: "secret",
+			Logger:    log,
+			Descriptors: map[CLIName]CLIDescriptor{
+				"tool1": {ProcessCommand: dummyHandlerSuccess, CredentialsFormat: "", ExampleCommand: "cmd"},
+				"tool2": {ProcessCommand: dummyHandlerSuccess, CredentialsFormat: "", ExampleCommand: "cmd"},
+			},
+			extension:                   dummyCoreExt,
+			DisableStop:                 true,
+			DisableSendToWebhookAdapter: true,
+		}
+		req := &CLIRunRequest{
+			CommandLine:   "cmd",
+			CommandTokens: []string{"cmd"},
+			Credentials:   "creds",
+			Tool:          "nonexistent",
+		}
+		resp := cliExtMulti.doRun(org, req, "ident", "inv")
+		expected := "unknown tool: nonexistent"
+		if resp.Error != expected {
+			t.Errorf("expected error: %s, got: %s", expected, resp.Error)
+		}
+		if resp.Retriable == nil || *resp.Retriable {
+			t.Errorf("expected retriable to be false")
+		}
+	})
+
+	// Test case: ProcessCommand returns context.DeadlineExceeded.
+	t.Run("ProcessCommand context.DeadlineExceeded", func(t *testing.T) {
+		cliExt.Descriptors["dummy"] = CLIDescriptor{ProcessCommand: dummyHandlerDeadline, CredentialsFormat: "", ExampleCommand: "cmd"}
+		req := &CLIRunRequest{
+			CommandLine:   "cmd",
+			CommandTokens: []string{"cmd"},
+			Credentials:   "creds",
+			Tool:          "dummy",
+		}
+		resp := cliExt.doRun(org, req, "ident", "inv")
+		// Expect error message to include DeadlineExceeded.
+		if !strings.Contains(resp.Error, "context deadline exceeded") {
+			t.Errorf("expected DeadlineExceeded error, got: %s", resp.Error)
+		}
+		if resp.Retriable == nil || *resp.Retriable {
+			t.Errorf("expected retriable to be false for DeadlineExceeded")
+		}
+	})
+
+	// Test case: ProcessCommand returns context.Canceled.
+	t.Run("ProcessCommand context.Canceled", func(t *testing.T) {
+		cliExt.Descriptors["dummy"] = CLIDescriptor{ProcessCommand: dummyHandlerCanceled, CredentialsFormat: "", ExampleCommand: "cmd"}
+		req := &CLIRunRequest{
+			CommandLine:   "cmd",
+			CommandTokens: []string{"cmd"},
+			Credentials:   "creds",
+			Tool:          "dummy",
+		}
+		resp := cliExt.doRun(org, req, "ident", "inv")
+		// Expect error message to include "canceled" (case-insensitive check).
+		if !strings.Contains(strings.ToLower(resp.Error), "canceled") {
+			t.Errorf("expected canceled error, got: %s", resp.Error)
+		}
+		if resp.Retriable == nil || *resp.Retriable {
+			t.Errorf("expected retriable to be false for canceled error")
+		}
+	})
+
+	// Test case: ProcessCommand returns a generic error.
+	t.Run("ProcessCommand generic error", func(t *testing.T) {
+		cliExt.Descriptors["dummy"] = CLIDescriptor{ProcessCommand: dummyHandlerGeneric, CredentialsFormat: "", ExampleCommand: "cmd"}
+		req := &CLIRunRequest{
+			CommandLine:   "cmd",
+			CommandTokens: []string{"cmd"},
+			Credentials:   "creds",
+			Tool:          "dummy",
+		}
+		resp := cliExt.doRun(org, req, "ident", "inv")
+		if resp.Error != "generic error" {
+			t.Errorf("expected generic error, got: %s", resp.Error)
+		}
+		if resp.Retriable == nil || !*resp.Retriable {
+			t.Errorf("expected retriable to be true for generic error")
+		}
+	})
+
+	// Test case: successful ProcessCommand execution.
+	t.Run("ProcessCommand success", func(t *testing.T) {
+		cliExt.Descriptors["dummy"] = CLIDescriptor{ProcessCommand: dummyHandlerSuccess, CredentialsFormat: "", ExampleCommand: "cmd"}
+		req := &CLIRunRequest{
+			CommandLine:   "cmd",
+			CommandTokens: []string{"cmd"},
+			Credentials:   "creds",
+			Tool:          "dummy",
+		}
+		resp := cliExt.doRun(org, req, "ident", "inv")
+		if resp.Error != "" {
+			t.Errorf("expected no error, got: %s", resp.Error)
+		}
+		// Verify that the returned data contains the expected output.
+		data, ok := resp.Data.(*CLIReturnData)
+		if !ok || data.OutputString != "success" {
+			t.Errorf("expected output 'success', got: %v", resp.Data)
+		}
+	})
+}

--- a/simplified/cli_test.go
+++ b/simplified/cli_test.go
@@ -1,3 +1,4 @@
+//nolint:unparam
 package simplified
 
 import (
@@ -14,12 +15,12 @@ import (
 // dummyLogger is a minimal implementation of limacharlie.LCLogger.
 type dummyLogger struct{}
 
-func (d dummyLogger) Info(msg string)  {}
-func (d dummyLogger) Error(msg string) {}
-func (d dummyLogger) Debug(msg string) {}
-func (d dummyLogger) Warn(msg string)  {}
-func (d dummyLogger) Fatal(msg string) {}
-func (d dummyLogger) Trace(msg string) {}
+func (d dummyLogger) Info(_ string)  {}
+func (d dummyLogger) Error(_ string) {}
+func (d dummyLogger) Debug(_ string) {}
+func (d dummyLogger) Warn(_ string)  {}
+func (d dummyLogger) Fatal(_ string) {}
+func (d dummyLogger) Trace(_ string) {}
 
 // dummyClientOptions holds minimal options to satisfy the client requirements.
 var dummyOpt = limacharlie.ClientOptions{

--- a/simplified/dr.go
+++ b/simplified/dr.go
@@ -14,13 +14,15 @@ import (
 	"github.com/refractionPOINT/lc-extension/core"
 )
 
-type GetRulesCallback = func(ctx context.Context) (RuleData, error)
-type RuleName = string
-type RuleNamespace = string
-type RuleInfo struct {
-	Tags []string
-	Data limacharlie.Dict
-}
+type (
+	GetRulesCallback = func(ctx context.Context) (RuleData, error)
+	RuleName         = string
+	RuleNamespace    = string
+	RuleInfo         struct {
+		Tags []string
+		Data limacharlie.Dict
+	}
+)
 type RuleData = map[RuleNamespace]map[RuleName]RuleInfo
 
 type RuleExtension struct {

--- a/simplified/lookup.go
+++ b/simplified/lookup.go
@@ -12,9 +12,11 @@ import (
 
 const updateRuleHive = "dr-managed"
 
-type GetLookupCallback = func(ctx context.Context) (LookupData, error)
-type LookupName = string
-type LookupData = map[LookupName]interface{}
+type (
+	GetLookupCallback = func(ctx context.Context) (LookupData, error)
+	LookupName        = string
+	LookupData        = map[LookupName]interface{}
+)
 
 type LookupExtension struct {
 	Name      string


### PR DESCRIPTION
## Description  

This pull request introduces explicit handling for retriable errors in our response structure and error handling logic. Previously, all errors were implicitly treated as retriable, which could lead to unintended behavior.  

With this change:  

- A new `Retriable` field is added to the `Response` struct, explicitly marking errors that should be retried.  
- By default, errors without the `Retriable` field are considered retriable for backward compatibility reasons.  
- HTTP responses now distinguish between retriable (503) and non-retriable (500) errors.  
- Errors like **context deadline exceeded** and **canceled context** are explicitly marked as non-retriable.
- Mark some common and fatal errors such as timeout, context canceled, invalid credentials and command not allowed as non-retriable. This includes exposing some new abstractions which can be used by the extensions to signal those types of errors.

Other changes

* Some mock based unit tests for scenarios we previously didn't have any tests. I needed to make some minor refactoring to make the code more conductive to unit testing (I went with package level variables, other approach by using an interface would add more complexity and require bigger refactor which is imo, not needed at this point)
* GHA workflow for running basic code quality checks (lint, unit tests)
* Address existing lint violations in the code so we can start from a clean state

## Background, Context  

While testing the **cloud CLI extension**, I noticed that some requests took **minutes** to complete. The root cause was that **we retried all errors**, including **non-retriable ones**, causing unnecessary delays. Instead of failing fast for errors that cannot be retried, the system kept retrying, leading to poor UX. 

## Notes

- I use a pointer to `bool` so we can distinguish between `Retriable` being `faise` and not being set / present (`nil`). This is needed for backward compatibility reasons.

## TODO

- [x] Basic unit tests

## Related PRs

- ext-cloud-cli changes -> https://github.com/refractionPOINT/ext-cloud-cli/pull/37
- legion extension manager changes -> https://github.com/refractionPOINT/legion_extension_manager/pull/159

## Links

- Tracking ticket - https://github.com/refractionPOINT/tracking/issues/3139
- Slack discussion - https://refractionpoint.slack.com/archives/C05KL51MSNA/p1741889962962769