### PR TITLE
fix: Implement and enforce idempotency in CreateExtensionAdapter

### DIFF
--- a/core/adapter.go
+++ b/core/adapter.go
@@ -3,27 +3,111 @@ package core
 import (
 	"crypto/sha256"
 	"fmt"
+	"slices"
 	"strings"
 
 	"github.com/refractionPOINT/go-limacharlie/limacharlie"
 )
 
-func (e *Extension) CreateExtensionAdapter(o *limacharlie.Organization, optMapping limacharlie.Dict) error {
-	privateTag := e.GetExtensionPrivateTag()
-	installationKey, err := o.AddInstallationKey(limacharlie.InstallationKey{
-		Description: e.getExtensionAdapterInstallationKeyDesc(),
-		Tags:        []string{"lc:system", privateTag},
+// An InstallationKey matches an Adapter iff:
+//   - The descriptions match
+//   - The InstallationKey's list of Tags contains the Adapter's PrivateTag
+func keyMatchesAdapter(k limacharlie.InstallationKey, desc, privateTag string) bool {
+	return k.Description == desc && slices.Contains(k.Tags, privateTag)
+}
+
+func (e *Extension) currentAdapterKey(hc *limacharlie.HiveClient, oid string) (string, error) {
+	rec, err := hc.Get(limacharlie.HiveArgs{
+		HiveName:     "cloud_sensor",
+		PartitionKey: oid,
+		Key:          e.ExtensionName,
 	})
 	if err != nil {
-		return fmt.Errorf("failed to create installation key for webhook adapter: %v", err)
+		if strings.Contains(err.Error(), "RECORD_NOT_FOUND") {
+			// If there is no adapter record for this extension, just return ""
+			return "", nil
+		}
+		return "", fmt.Errorf("reading cloud_sensor record: %w", err)
 	}
 
-	oid := o.GetOID()
-	isTrue := true
-	hc := limacharlie.NewHiveClient(o)
+	// Extract installation key from Data.webhook.client_options.identity.installation_key
+	webhook, ok := rec.Data["webhook"].(map[string]interface{})
+	if !ok {
+		return "", nil
+	}
+	co, ok := webhook["client_options"].(map[string]interface{})
+	if !ok {
+		return "", nil
+	}
+	identity, ok := co["identity"].(map[string]interface{})
+	if !ok {
+		return "", nil
+	}
+	installationKey, _ := identity["installation_key"].(string)
+	return installationKey, nil
+}
 
+func (e *Extension) CreateExtensionAdapter(o *limacharlie.Organization, optMapping limacharlie.Dict) error {
+	privateTag := e.GetExtensionPrivateTag()
+	desc := e.getExtensionAdapterInstallationKeyDesc()
+	oid := o.GetOID()
+	hc := limacharlie.NewHiveClient(o)
+	isTrue := true
 	if optMapping == nil {
 		optMapping = limacharlie.Dict{}
+	}
+
+	keys, err := o.InstallationKeys()
+	if err != nil {
+		return fmt.Errorf("failed to list installation keys: %v", err)
+	}
+
+	// Get all installation keys that match this extension.
+	var matching []limacharlie.InstallationKey
+	for _, k := range keys {
+		if keyMatchesAdapter(k, desc, privateTag) {
+			matching = append(matching, k)
+		}
+	}
+
+	// Resolve installationKey to either an existing key, or a new one.
+	var installationKey string
+	if len(matching) > 0 {
+		current, err := e.currentAdapterKey(hc, oid)
+		if err != nil {
+			return err
+		}
+		// If any of the keys for this extension match the one currently
+		// in Hive, use that one.
+		for _, k := range matching {
+			if k.ID == current {
+				installationKey = k.ID
+				break
+			}
+		}
+
+		// Otherwise, just pick one.
+		if installationKey == "" {
+			installationKey = matching[0].ID
+		}
+
+		// Clean up any duplicative keys
+		for _, k := range matching {
+			if k.ID != installationKey {
+				err := o.DelInstallationKey(k.ID)
+				if err != nil {
+					return fmt.Errorf("failed to delete duplicate installation key: %v", err)
+				}
+			}
+		}
+	} else {
+		installationKey, err = o.AddInstallationKey(limacharlie.InstallationKey{
+			Description: desc,
+			Tags:        []string{"lc:system", privateTag},
+		})
+		if err != nil {
+			return fmt.Errorf("failed to create installation key for webhook adapter: %v", err)
+		}
 	}
 
 	if _, err = hc.Add(limacharlie.HiveArgs{

--- a/core/adapter.go
+++ b/core/adapter.go
@@ -47,6 +47,9 @@ func (e *Extension) currentAdapterKey(hc *limacharlie.HiveClient, oid string) (s
 	return installationKey, nil
 }
 
+// CreateExtensionAdapter ensures exactly one webhook-adapter installation key
+// exists for this extension. It is idempotent and self-healing: it only
+// creates a key when none exist, and it deletes any duplicates.
 func (e *Extension) CreateExtensionAdapter(o *limacharlie.Organization, optMapping limacharlie.Dict) error {
 	privateTag := e.GetExtensionPrivateTag()
 	desc := e.getExtensionAdapterInstallationKeyDesc()
@@ -86,18 +89,20 @@ func (e *Extension) CreateExtensionAdapter(o *limacharlie.Organization, optMappi
 			}
 		}
 
-		// Otherwise, just pick one.
+		// Otherwise, fall back to a deterministic survivor: the smallest ID.
 		if installationKey == "" {
-			installationKey = matching[0].ID
+			installationKey = slices.MinFunc(matching, func(a, b limacharlie.InstallationKey) int {
+				return strings.Compare(a.ID, b.ID)
+			}).ID
 		}
 
-		// Clean up any duplicative keys
+		// Clean up any duplicative keys. DelInstallationKey is idempotent.
 		for _, k := range matching {
-			if k.ID != installationKey {
-				err := o.DelInstallationKey(k.ID)
-				if err != nil {
-					return fmt.Errorf("failed to delete duplicate installation key: %v", err)
-				}
+			if k.ID == installationKey {
+				continue
+			}
+			if err := o.DelInstallationKey(k.ID); err != nil {
+				return fmt.Errorf("failed to delete duplicate installation key: %v", err)
 			}
 		}
 	} else {

--- a/core/adapter_test.go
+++ b/core/adapter_test.go
@@ -1,0 +1,115 @@
+package core
+
+import (
+	"testing"
+
+	"github.com/refractionPOINT/go-limacharlie/limacharlie"
+)
+
+func TestIdempotentCreateExtensionAdapter(t *testing.T) {
+	ms := limacharlie.NewMockServer("oid-test")
+	defer ms.Close()
+	org, err := ms.NewOrganization()
+	if err != nil {
+		t.Fatalf("TestIdempotentCreateExtensionAdapter error: %s", err)
+	}
+	ext := &Extension{ExtensionName: "my-ext", SecretKey: "secret"}
+
+	// Call CreateExtensionAdapter() multiple times to exercise idempotency
+	for range 3 {
+		if err := ext.CreateExtensionAdapter(org, limacharlie.Dict{}); err != nil {
+			t.Fatalf("CreateExtensionAdapter failed: %s", err)
+		}
+	}
+
+	// Verify that only one key exists in InstallationKeyStore
+	numKeys := len(ms.InstallationKeyStore)
+	if numKeys != 1 {
+		t.Errorf("TestIdempotentCreateExtensionAdapter error: InstallationKeyStore has %d keys, wanted 1", numKeys)
+	}
+}
+
+func TestCreateExtensionAdapterDuplicateKeyCleanup(t *testing.T) {
+	ms := limacharlie.NewMockServer("oid-test")
+	defer ms.Close()
+	org, err := ms.NewOrganization()
+	if err != nil {
+		t.Fatalf("TestCreateExtensionAdapterDuplicateKeyCleanup error: %s", err)
+	}
+	ext := &Extension{ExtensionName: "my-ext", SecretKey: "secret"}
+	desc := ext.getExtensionAdapterInstallationKeyDesc()
+	tag := ext.GetExtensionPrivateTag()
+
+	// Pre-seed some duplicative installation keys
+	for _, iid := range []string{"iid-1", "iid-2", "iid-3"} {
+		ms.InstallationKeyStore[iid] = limacharlie.InstallationKey{
+			ID:          iid,
+			Description: desc,
+			Tags:        []string{"lc:system", tag},
+		}
+	}
+
+	if err := ext.CreateExtensionAdapter(org, limacharlie.Dict{}); err != nil {
+		t.Fatalf("CreateExtensionAdapter failed: %s", err)
+	}
+
+	// Verify that only one key remains in InstallationKeyStore
+	numKeys := len(ms.InstallationKeyStore)
+	if numKeys != 1 {
+		t.Errorf("TestCreateExtensionAdapterDuplicateKeyCleanup error: InstallationKeyStore has %d keys, wanted 1", numKeys)
+	}
+}
+
+func TestCreateExtensionAdapterActiveKeyRemains(t *testing.T) {
+	const oid = "oid-test"
+	ms := limacharlie.NewMockServer(oid)
+	defer ms.Close()
+	org, err := ms.NewOrganization()
+	if err != nil {
+		t.Fatalf("TestCreateExtensionAdapterActiveKeyRemains error: %s", err)
+	}
+	ext := &Extension{ExtensionName: "my-ext", SecretKey: "secret"}
+	desc := ext.getExtensionAdapterInstallationKeyDesc()
+	tag := ext.GetExtensionPrivateTag()
+
+	// Pre-seed some duplicative installation keys
+	for _, iid := range []string{"iid-1", "iid-2", "iid-3"} {
+		ms.InstallationKeyStore[iid] = limacharlie.InstallationKey{
+			ID:          iid,
+			Description: desc,
+			Tags:        []string{"lc:system", tag},
+		}
+	}
+
+	// Add a Hive record pointing to iid-2
+	hiveRecord := map[string]limacharlie.HiveData{
+		ext.ExtensionName: {
+			Data: map[string]interface{}{
+				"webhook": map[string]interface{}{
+					"client_options": map[string]interface{}{
+						"identity": map[string]interface{}{
+							"installation_key": "iid-2",
+						},
+					},
+				},
+			},
+		},
+	}
+	ms.HiveStore["cloud_sensor/"+oid] = hiveRecord
+
+	if err := ext.CreateExtensionAdapter(org, limacharlie.Dict{}); err != nil {
+		t.Fatalf("CreateExtensionAdapter failed: %s", err)
+	}
+
+	// Verify that only one key remains in InstallationKeyStore...
+	numKeys := len(ms.InstallationKeyStore)
+	if numKeys != 1 {
+		t.Errorf("TestCreateExtensionAdapterActiveKeyRemains error: InstallationKeyStore has %d keys, wanted 1", numKeys)
+	}
+
+	// ...and that it's iid-2
+	_, ok := ms.InstallationKeyStore["iid-2"]
+	if !ok {
+		t.Errorf("TestCreateExtensionAdapterActiveKeyRemains error: active key iid-2 was deleted")
+	}
+}


### PR DESCRIPTION
## Description of the change

Previous implementation leaked installation keys by creating a new one each time the function was called.

New implementation checks to see if a matching key exists, and uses it if it does. Any extra matching keys are deleted.

If no matching key exists, a new one is created.

See https://refractionpoint.slack.com/archives/C02G3J27URZ/p1781561618363129 for customer report of issue.

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
