### PR TITLE
feat(cli): optionally persist command output in the run event

### DIFF
--- a/simplified/cli.go
+++ b/simplified/cli.go
@@ -24,6 +24,13 @@ type CLIDescriptor struct {
 	ProcessCommand    CLIHandler
 	CredentialsFormat string
 	ExampleCommand    string
+
+	// IncludeOutputInEvent, when true, persists the command's output in the
+	// "run" event on success so it can be used by D&R rules, bidirectionality,
+	// and an immutable history (#3950). It defaults to false because the output
+	// is not redacted and some tools return secrets (e.g. 1Password `op item
+	// get`); only enable it for tools whose output is safe to persist.
+	IncludeOutputInEvent bool
 }
 
 type CLIReturnData struct {
@@ -383,6 +390,14 @@ func (e *CLIExtension) doRun(o *limacharlie.Organization, request *CLIRunRequest
 		// CLI arguments, credentials, etc.
 		e.Logger.Info(fmt.Sprintf("command for %s and tool %s failed and took %f seconds: %v", o.GetOID(), request.Tool, elapsed.Seconds(), err))
 	} else {
+		// Persist the command output in the event so results aren't ephemeral,
+		// enabling D&R rules, bidirectionality, and an immutable history (#3950).
+		// Gated per-tool and off by default: output is not redacted and some
+		// tools return secrets (e.g. 1Password `op item get`), so only tools
+		// that opt in have their successful output written to the event stream.
+		if handler.IncludeOutputInEvent {
+			hook["response"] = &resp
+		}
 		e.Logger.Debug(fmt.Sprintf("command for %s and tool %s succeeded and took %f seconds", o.GetOID(), request.Tool, elapsed.Seconds()))
 	}
 

--- a/simplified/cli_test.go
+++ b/simplified/cli_test.go
@@ -355,3 +355,77 @@ func TestIsErrorRetriable(t *testing.T) {
 		})
 	}
 }
+
+// TestDoRun_SuccessOutputInEvent verifies the per-tool opt-in that controls
+// whether a successful command's output is persisted in the run event (#3950).
+// Output is included only when the descriptor sets IncludeOutputInEvent, so
+// secret-returning tools don't leak output into the event stream by default.
+func TestDoRun_SuccessOutputInEvent(t *testing.T) {
+	originalSendToWebhook := sendToWebhookAdapterFunc
+	originalStopThisInstance := stopThisInstanceFunc
+	defer func() {
+		sendToWebhookAdapterFunc = originalSendToWebhook
+		stopThisInstanceFunc = originalStopThisInstance
+	}()
+	stopThisInstanceFunc = func(_ limacharlie.LCLogger, _ *limacharlie.Organization, _ *CLIRunRequest, _ string) {}
+
+	org, err := limacharlie.NewOrganizationFromClientOptions(dummyOpt, dummyLogger{})
+	if err != nil {
+		t.Fatalf("failed to create organization: %v", err)
+	}
+
+	run := func(includeOutput bool) limacharlie.Dict {
+		var capturedHook limacharlie.Dict
+		sendToWebhookAdapterFunc = func(_ *core.Extension, _ *limacharlie.Organization, hook limacharlie.Dict) error {
+			capturedHook = hook
+			return nil
+		}
+		cliExt := &CLIExtension{
+			Name:      "test-extension",
+			SecretKey: "secret",
+			Logger:    dummyLogger{},
+			Descriptors: map[CLIName]CLIDescriptor{
+				"dummy": {
+					ProcessCommand: func(_ context.Context, _ []string, _ string) (CLIReturnData, error) {
+						return CLIReturnData{StatusCode: 0, OutputString: "hello-output"}, nil
+					},
+					IncludeOutputInEvent: includeOutput,
+				},
+			},
+			extension: dummyCoreExt,
+		}
+		req := &CLIRunRequest{CommandLine: "cmd", CommandTokens: []string{"cmd"}, Credentials: "creds", Tool: "dummy"}
+		resp := cliExt.doRun(org, req, "ident", "inv")
+		if resp.Error != "" {
+			t.Fatalf("expected no error, got: %s", resp.Error)
+		}
+		if capturedHook == nil {
+			t.Fatal("expected webhook to be called with a hook")
+		}
+		if capturedHook["action"] != "run" {
+			t.Errorf("expected action 'run', got %v", capturedHook["action"])
+		}
+		if _, hasErr := capturedHook["error"]; hasErr {
+			t.Errorf("did not expect an error field on success, got: %v", capturedHook["error"])
+		}
+		return capturedHook
+	}
+
+	t.Run("opted in includes output", func(t *testing.T) {
+		hook := run(true)
+		respData, ok := hook["response"].(*CLIReturnData)
+		if !ok {
+			t.Fatalf("expected hook[\"response\"] to be *CLIReturnData, got: %T", hook["response"])
+		}
+		if respData.OutputString != "hello-output" {
+			t.Errorf("expected output 'hello-output' in event, got: %q", respData.OutputString)
+		}
+	})
+
+	t.Run("default off omits output", func(t *testing.T) {
+		hook := run(false)
+		if _, hasResp := hook["response"]; hasResp {
+			t.Errorf("expected no response in event when opt-in is off, got: %v", hook["response"])
+		}
+	})
+}


### PR DESCRIPTION
## What

Adds an opt-in, per-tool `CLIDescriptor.IncludeOutputInEvent` flag (default **false**). When a tool sets it, that tool's **successful** command output is persisted in the `run` event (it was already included on the error path). Off by default.

## Why

Resolves [tracking #3950](https://github.com/refractionPOINT/tracking/issues/3950). On success, `doRun` emitted only invocation metadata (`action/request/by/inv_id`) — the output was returned synchronously to the caller but never stored as an event, so D&R rules, bidirectionality, and an immutable history had nothing to act on.

## Why opt-in (default off) and per-tool

The persisted output is **not redacted**, and some tools registered on `CLIExtension` return secrets — most obviously 1Password (`op item get`). Always-on would newly write those secrets into the event stream on the common (success) path. So:

- **Default off** — no behavior change and no new exposure unless a tool explicitly opts in.
- **Per-tool** — sensitivity is a property of the tool/command, so the descriptor author decides. Cloud-inventory tools (gcloud/aws/az/…) can safely opt in; secret-returning tools stay off.

Error-path behavior is unchanged (pre-existing; output already included on error).

## Tests

`TestDoRun_SuccessOutputInEvent` covers both branches:
- opted in → `response` present in the event with the command output;
- default off → no `response` field.

`go build ./...`, `go vet ./simplified/`, full `go test ./simplified/` all pass.

## Follow-up (separate PR, after this merges + is tagged)

`ext-cloud-cli` will bump this dependency and opt in its cloud tools. For 1Password it will add a concealed-field masker (force JSON + redact `CONCEALED` fields) and deny emission for raw-secret subcommands like `op read` before opting `op` in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)