### PR TITLE
CreateExtensionAdapter: Handle failure in lookup of current installation key

### DIFF
--- a/core/adapter.go
+++ b/core/adapter.go
@@ -76,12 +76,11 @@ func (e *Extension) CreateExtensionAdapter(o *limacharlie.Organization, optMappi
 	// Resolve installationKey to either an existing key, or a new one.
 	var installationKey string
 	if len(matching) > 0 {
+		// Best-effort attempt to use the current adapter key if we can.
 		current, err := e.currentAdapterKey(hc, oid)
 		if err != nil {
-			return err
+			current = ""
 		}
-		// If any of the keys for this extension match the one currently
-		// in Hive, use that one.
 		for _, k := range matching {
 			if k.ID == current {
 				installationKey = k.ID


### PR DESCRIPTION
## Description of the change

If we can't determine what the currently-active installation key is (e.g. due to a permissions error), just fall through to the logic for deterministically picking one to use.

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
