### PR TITLE
Update CI Go matrix and golangci-lint for go.mod 1.25.9 requirement

### DIFF
--- a/.github/workflows/code-quality.yaml
+++ b/.github/workflows/code-quality.yaml
@@ -41,9 +41,9 @@ jobs:
           test -z "$(go fmt ./...)" || (echo "Code needs formatting, run go fmt ./..." && exit 1)
 
       - name: Run golangci-lint
-        uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20  # v9.2.0
+        uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a  # v9.3.0
         with:
-          version: v2.3.0
+          version: v2.12.2
           # There are existing issues in the code which haven't been fixed yet so for now, only report new issues
           only-new-issues: true
 
@@ -56,8 +56,8 @@ jobs:
       fail-fast: false
       matrix:
         go_version:
-          - "1.24"
           - "1.25"
+          - "1.26"
         os:
           - ubuntu-latest
 


### PR DESCRIPTION
## Summary
Since go.mod moved to `go 1.25.9`, two Code Quality workflow jobs fail structurally on every PR:

- **Unit Tests (Go 1.24)** — `go: go.mod requires go >= 1.25.9 (running go 1.24.13; GOTOOLCHAIN=local)`
- **Code Quality** — `the Go language version (go1.24) used to build golangci-lint is lower than the targeted Go version (1.25.9)` (golangci-lint v2.3.0 is a go1.24 build)

Changes:
- Unit test matrix: `1.24, 1.25` → `1.25, 1.26`
- golangci-lint v2.3.0 → v2.12.2 (action pinned to v9.3.0); `only-new-issues: true` retained

## Validation (local)
- `go test ./... -race` on Go 1.25.9 — all packages pass
- `go test ./...` in `golang:1.26` container — all packages pass
- `golangci-lint run` with v2.12.2 image — config loads and lints cleanly (reports the 64 known pre-existing issues; gated by only-new-issues in CI)