### PR TITLE
Allow overriding API and JWT URLs via LC_API_URL / LC_JWT_URL

### DIFF
--- a/core/extension.go
+++ b/core/extension.go
@@ -283,9 +283,13 @@ func (e *Extension) generateSDK(oad common.OrgAccessData) (*limacharlie.Organiza
 	if e.OrgFromAccess != nil {
 		return e.OrgFromAccess(oad)
 	}
+	// LC_API_URL / LC_JWT_URL override the production endpoints so an
+	// extension can run against a local or test stack; empty means default.
 	return limacharlie.NewOrganizationFromClientOptions(limacharlie.ClientOptions{
-		OID: oad.OID,
-		JWT: oad.JWT,
+		OID:    oad.OID,
+		JWT:    oad.JWT,
+		URL:    os.Getenv("LC_API_URL"),
+		JWTURL: os.Getenv("LC_JWT_URL"),
 	}, nil)
 }
 

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/refractionPOINT/lc-extension
 go 1.25.9
 
 require (
-	github.com/refractionPOINT/go-limacharlie/limacharlie v0.0.0-20260508000415-db50466f3ab1
+	github.com/refractionPOINT/go-limacharlie/limacharlie v0.0.0-20260730214850-66dd27031dd3
 	github.com/refractionPOINT/shlex v0.0.0-20240130182828-ebac721e86ed
 )
 

--- a/go.sum
+++ b/go.sum
@@ -79,8 +79,8 @@ github.com/planetscale/vtprotobuf v0.6.1-0.20240319094008-0393e58bdf10 h1:GFCKgm
 github.com/planetscale/vtprotobuf v0.6.1-0.20240319094008-0393e58bdf10/go.mod h1:t/avpk3KcrXxUnYOhZhMXJlSEyie6gQbtLq5NM3loB8=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRIccs7FGNTlIRMkT8wgtp5eCXdBlqhYGL6U=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
-github.com/refractionPOINT/go-limacharlie/limacharlie v0.0.0-20260508000415-db50466f3ab1 h1:E5yEWQ0DlaLOSmMSdHlMV9RpAEApQlmXRbjnRc4yem4=
-github.com/refractionPOINT/go-limacharlie/limacharlie v0.0.0-20260508000415-db50466f3ab1/go.mod h1:cxKaxCVmTuyMP0oNmLtyzEI0vrHlvtoFU6U5tOvx0fQ=
+github.com/refractionPOINT/go-limacharlie/limacharlie v0.0.0-20260730214850-66dd27031dd3 h1:X6RR9+INNBlFMkj5WsBu3oMJG+mTOkwJEmbUvALXadM=
+github.com/refractionPOINT/go-limacharlie/limacharlie v0.0.0-20260730214850-66dd27031dd3/go.mod h1:zMSDtfyjPOSNBecj04tua7PZK71UmaBdh6LDYMwQsk0=
 github.com/refractionPOINT/shlex v0.0.0-20240130182828-ebac721e86ed h1:d9SCvhFrnSfTOmgnsmAQIqMqNKeZ+eMGw7itGRJgRmE=
 github.com/refractionPOINT/shlex v0.0.0-20240130182828-ebac721e86ed/go.mod h1:vrBdshTXdAtG5MncHgvdx+N4R5zaKXFz4nnlxd+yqMs=
 github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0tI/otEQ=


### PR DESCRIPTION
## Why
Extensions built on this SDK hardcode production endpoints in `generateSDK()`, which makes it impossible to run a real extension against the local stack (or any test environment): callbacks like hive writes on subscribe always target `api.limacharlie.io`.

With this change, `LC_API_URL` / `LC_JWT_URL` env vars override the endpoints; unset, behavior is unchanged (empty string → SDK defaults).

Validated end to end today by running ext-exfil against the local stack (extension-manager subscribe → hive writes via local lc-api → sync request round-trip) while diagnosing the REGISTRY_GET_REP drop (refractionPOINT/ext-exfil#60).

## Changes
- `core/extension.go`: pass `URL`/`JWTURL` from env in `generateSDK()`.
- Bump go-limacharlie to master for `ClientOptions.URL`/`JWTURL` (go-limacharlie#248).

## Test plan
- `go build ./...`; `go test ./core/... ./simulator/...` pass.
- ext-exfil built against this branch ran the full local-stack subscribe + sync flow.