### PR TITLE
ci: migrate CodeQL to advanced setup

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,44 @@
+name: CodeQL
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+  schedule:
+    - cron: '9 6 * * 1'
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      packages: read
+      actions: read
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - language: go
+            build-mode: autobuild
+          - language: python
+            build-mode: none
+          - language: actions
+            build-mode: none
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v4
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: ${{ matrix.build-mode }}
+          queries: security-extended
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v4
+        with:
+          category: "/language:${{ matrix.language }}"


### PR DESCRIPTION
## Summary
Migrates CodeQL scanning from GitHub's default setup to an advanced-setup workflow checked into the repo.

## Why
Default setup force-enables dependency caching for Go scans with no opt-out. This repo is currently healthy, but the same mechanism took down CodeQL in go-essentials and legion_endpoint-go this month: the saved module cache bloats over time until restoring it fills the runner disk, after which every scan fails and the poisoned cache self-perpetuates (default-setup "dynamic" runs cannot be re-run or debugged from logs). This change proactively removes that failure class.

The checked-in workflow:
- leaves dependency caching off (the advanced-setup default), eliminating the poisoned-cache loop; Go modules are downloaded fresh each run (verified: full scans complete in ~5 minutes)
- keeps coverage identical to the previous configuration: same languages, `security-extended` query suite, weekly scheduled scan
- restores normal Actions ergonomics: re-runnable jobs and real logs

Default setup has been disabled on this repo as part of this change (required — GitHub rejects advanced-setup result uploads while it is enabled).

## Test plan
- CodeQL workflow runs on this PR for all configured languages and uploads results cleanly
- After merge: scheduled and push-triggered scans appear under Security → Code scanning
